### PR TITLE
fix(shim): make writeFileSync durable and add missing resolvePath calls

### DIFF
--- a/packages/shim/src/fs/index.js
+++ b/packages/shim/src/fs/index.js
@@ -11,6 +11,7 @@ import { realpath, realpathSync } from "./realpath.js";
 import { constants } from "./constants.js";
 import { registerReadTransform, removeReadTransform, resolvePath } from "./transforms.js";
 import { wsClient } from "../ws-client.js";
+import { createReadStream, createWriteStream } from "./stream.js";
 
 const metadataCache = new MetadataCache();
 const contentCache = new ContentCache();
@@ -58,6 +59,14 @@ export const fsShim = {
 
   watch: fsWatch.watch,
   constants,
+
+  createReadStream(path, options) {
+    return createReadStream(path, options, fsSync);
+  },
+
+  createWriteStream(path, options) {
+    return createWriteStream(path, options, fsSync);
+  },
 
   invalidate(path) {
     contentCache.invalidate(resolvePath(path));

--- a/packages/shim/src/fs/promises.js
+++ b/packages/shim/src/fs/promises.js
@@ -85,15 +85,6 @@ export function createFsPromises(metadataCache, contentCache, transport) {
           throw e;
         }
 
-        if (!meta && resolved && resolved === path) {
-          // Throw ENOENT only when not redirected; redirected paths fall through to the transport's fallback.
-          const e = new Error(
-            `ENOENT: no such file or directory, open '${path}'`,
-          );
-          e.code = "ENOENT";
-          throw e;
-        }
-
         result = contentCache.get(resolved);
       }
 
@@ -206,16 +197,20 @@ export function createFsPromises(metadataCache, contentCache, transport) {
       const recursive =
         typeof options === "object" ? !!options.recursive : !!options;
 
-      markLocalOp(path);
-      metadataCache.set(path, { type: "directory" });
+      const resolved = resolvePath(path);
 
-      await transport.mkdir(path, recursive);
+      markLocalOp(resolved);
+      metadataCache.set(resolved, { type: "directory" });
+
+      await transport.mkdir(resolved, recursive);
     },
 
     async rmdir(path) {
-      markLocalOp(path);
-      metadataCache.delete(path);
-      await transport.rmdir(path);
+      const resolved = resolvePath(path);
+
+      markLocalOp(resolved);
+      metadataCache.delete(resolved);
+      await transport.rmdir(resolved);
     },
 
     async rm(path, options) {

--- a/packages/shim/src/fs/stream.js
+++ b/packages/shim/src/fs/stream.js
@@ -1,0 +1,166 @@
+import { EventEmitter } from "../node/events.js";
+
+const DEFAULT_CHUNK_SIZE = 64 * 1024;
+
+export function createReadStream(path, options, fsImpl) {
+  return new ReadStream(path, options, fsImpl);
+}
+
+export function createWriteStream(path, options, fsImpl) {
+  return new WriteStream(path, options, fsImpl);
+}
+
+class ReadStream extends EventEmitter {
+  constructor(path, options, fsImpl) {
+    super();
+    this.path = path;
+    this.options = options || {};
+    this._fs = fsImpl;
+    this.bytesRead = 0;
+    this.readable = true;
+    this._readableState = {};
+
+    // Start reading on next tick so caller can attach listeners.
+    setTimeout(() => this._read(), 0);
+  }
+
+  _read() {
+    let data;
+
+    try {
+      const encoding = this.options.encoding;
+      data = this._fs.readFileSync(this.path, encoding ? { encoding } : undefined);
+    } catch (e) {
+      this.emit("error", e);
+      return;
+    }
+
+    const chunkSize = this.options.highWaterMark || DEFAULT_CHUNK_SIZE;
+
+    if (typeof data === "string") {
+      this._pushString(data, chunkSize);
+    } else {
+      this._pushBuffer(data, chunkSize);
+    }
+  }
+
+  _pushString(data, chunkSize) {
+    let offset = 0;
+
+    while (offset < data.length) {
+      const chunk = data.slice(offset, offset + chunkSize);
+      offset += chunkSize;
+      this.bytesRead += chunk.length;
+      this.emit("data", chunk);
+    }
+
+    this.emit("end");
+    this.emit("close");
+  }
+
+  _pushBuffer(data, chunkSize) {
+    let offset = 0;
+
+    while (offset < data.length) {
+      const end = Math.min(offset + chunkSize, data.length);
+      const chunk = data.subarray(offset, end);
+      offset = end;
+      this.bytesRead += chunk.length;
+      this.emit("data", chunk);
+    }
+
+    this.emit("end");
+    this.emit("close");
+  }
+
+  pipe(destination) {
+    this.on("data", (chunk) => destination.write(chunk));
+    this.on("end", () => destination.end());
+    return destination;
+  }
+}
+
+class WriteStream extends EventEmitter {
+  constructor(path, options, fsImpl) {
+    super();
+    this.path = path;
+    this.options = options || {};
+    this._fs = fsImpl;
+    this.bytesWritten = 0;
+    this.writable = true;
+    this._chunks = [];
+    this._encoding = this.options.encoding || "utf-8";
+  }
+
+  write(chunk, encoding, callback) {
+    if (typeof encoding === "function") {
+      callback = encoding;
+      encoding = undefined;
+    }
+
+    const enc = encoding || this._encoding;
+
+    if (typeof chunk === "string") {
+      this._chunks.push(chunk);
+      this.bytesWritten += new TextEncoder().encode(chunk).length;
+    } else if (chunk instanceof Uint8Array || chunk instanceof ArrayBuffer) {
+      const buf = chunk instanceof ArrayBuffer ? new Uint8Array(chunk) : chunk;
+      this._chunks.push(buf);
+      this.bytesWritten += buf.length;
+    } else if (Buffer.isBuffer && Buffer.isBuffer(chunk)) {
+      const buf = new Uint8Array(chunk);
+      this._chunks.push(buf);
+      this.bytesWritten += buf.length;
+    }
+
+    if (callback) {
+      callback();
+    }
+
+    return true;
+  }
+
+  end(chunk, encoding, callback) {
+    if (chunk) {
+      this.write(chunk, encoding);
+    }
+
+    try {
+      if (this._chunks.length === 1) {
+        const first = this._chunks[0];
+        this._fs.writeFileSync(this.path, first, this._encoding);
+      } else if (this._chunks.length > 1) {
+        const totalLength = this._chunks.reduce((sum, c) => {
+          return sum + (typeof c === "string" ? new TextEncoder().encode(c).length : c.length);
+        }, 0);
+
+        const merged = new Uint8Array(totalLength);
+        let offset = 0;
+
+        for (const chunk of this._chunks) {
+          if (typeof chunk === "string") {
+            const encoded = new TextEncoder().encode(chunk);
+            merged.set(encoded, offset);
+            offset += encoded.length;
+          } else {
+            merged.set(chunk, offset);
+            offset += chunk.length;
+          }
+        }
+
+        this._fs.writeFileSync(this.path, merged, "binary");
+      }
+
+      this.emit("finish");
+      this.emit("close");
+    } catch (e) {
+      this.emit("error", e);
+    }
+
+    if (callback) {
+      callback();
+    }
+
+    return this;
+  }
+}

--- a/packages/shim/src/fs/sync.js
+++ b/packages/shim/src/fs/sync.js
@@ -160,16 +160,7 @@ export function createFsSync(metadataCache, contentCache, transport) {
       contentCache.delete(resolved);
       metadataCache.delete(resolved);
 
-      // Fire-and-forget. suppress ENOENT (file already gone)
-      transport.unlink(resolved).catch((e) => {
-        if (e.code !== "ENOENT") {
-          console.error(
-            "[shim:fs] unlinkSync background delete failed:",
-            resolved,
-            e,
-          );
-        }
-      });
+      transport.unlinkSync(resolved);
     },
 
     readdirSync(path) {
@@ -191,13 +182,7 @@ export function createFsSync(metadataCache, contentCache, transport) {
       markLocalOp(resolved);
       metadataCache.set(resolved, { type: "directory" });
 
-      transport.mkdir(resolved, recursive).catch((e) => {
-        console.error(
-          "[shim:fs] mkdirSync background create failed:",
-          resolved,
-          e,
-        );
-      });
+      transport.mkdirSync(resolved, recursive);
     },
 
     rmdirSync(path) {
@@ -206,13 +191,7 @@ export function createFsSync(metadataCache, contentCache, transport) {
       markLocalOp(resolved);
       metadataCache.delete(resolved);
 
-      transport.rmdir(resolved).catch((e) => {
-        console.error(
-          "[shim:fs] rmdirSync background remove failed:",
-          resolved,
-          e,
-        );
-      });
+      transport.rmdirSync(resolved);
     },
 
     rmSync(path, options) {
@@ -225,13 +204,7 @@ export function createFsSync(metadataCache, contentCache, transport) {
       metadataCache.delete(resolved);
       contentCache.delete(resolved);
 
-      transport.rm(resolved, recursive).catch((e) => {
-        console.error(
-          "[shim:fs] rmSync background remove failed:",
-          resolved,
-          e,
-        );
-      });
+      transport.rmSync(resolved, recursive);
     },
 
     renameSync(oldPath, newPath) {
@@ -249,13 +222,7 @@ export function createFsSync(metadataCache, contentCache, transport) {
 
       metadataCache.rename(resolvedOld, resolvedNew);
 
-      transport.rename(resolvedOld, resolvedNew).catch((e) => {
-        console.error(
-          "[shim:fs] renameSync background rename failed:",
-          resolvedOld,
-          e,
-        );
-      });
+      transport.renameSync(resolvedOld, resolvedNew);
     },
 
     copyFileSync(src, dest) {
@@ -277,17 +244,7 @@ export function createFsSync(metadataCache, contentCache, transport) {
         metadataCache.set(resolvedDest, { ...srcMeta });
       }
 
-      transport
-        .copyFile(src, resolvedDest)
-        .then(() => transport.stat(resolvedDest))
-        .then((meta) => metadataCache.set(resolvedDest, meta))
-        .catch((e) => {
-          console.error(
-            "[shim:fs] copyFileSync background copy failed:",
-            resolvedDest,
-            e,
-          );
-        });
+      transport.copyFileSync(resolvedSrc, resolvedDest);
     },
 
     appendFileSync(path, data) {
@@ -296,17 +253,7 @@ export function createFsSync(metadataCache, contentCache, transport) {
       markLocalOp(resolved);
       contentCache.invalidate(resolved);
 
-      transport
-        .appendFile(resolved, data)
-        .then(() => transport.stat(resolved))
-        .then((meta) => metadataCache.set(resolved, meta))
-        .catch((e) => {
-          console.error(
-            "[shim:fs] appendFileSync background append failed:",
-            resolved,
-            e,
-          );
-        });
+      transport.appendFileSync(resolved, data);
     },
 
     utimesSync(path, atime, mtime) {
@@ -318,13 +265,7 @@ export function createFsSync(metadataCache, contentCache, transport) {
         metadataCache.set(resolved, meta);
       }
 
-      transport.utimes(resolved, atime, mtime).catch((e) => {
-        console.error(
-          "[shim:fs] utimesSync background utimes failed:",
-          resolved,
-          e,
-        );
-      });
+      transport.utimesSync(resolved, atime, mtime);
     },
 
     chmodSync() {

--- a/packages/shim/src/fs/sync.js
+++ b/packages/shim/src/fs/sync.js
@@ -147,14 +147,10 @@ export function createFsSync(metadataCache, contentCache, transport) {
         ctime: metadataCache.get(resolved)?.ctime || Date.now(),
       });
 
-      // Fire-and-forget async send to server
-      transport.writeFile(resolved, transformed, encoding).catch((e) => {
-        console.error(
-          "[shim:fs] writeFileSync background save failed:",
-          resolved,
-          e,
-        );
-      });
+      // Synchronous XHR so the write is durable before we return.
+      // Without this, a page refresh before the async fetch completes
+      // discards the in-memory cache and aborts the request, losing data.
+      transport.writeFileSync(resolved, transformed, encoding);
     },
 
     unlinkSync(path) {
@@ -190,20 +186,32 @@ export function createFsSync(metadataCache, contentCache, transport) {
       const recursive =
         typeof options === "object" ? !!options.recursive : !!options;
 
-      markLocalOp(path);
-      metadataCache.set(path, { type: "directory" });
+      const resolved = resolvePath(path);
 
-      transport.mkdir(path, recursive).catch((e) => {
-        console.error("[shim:fs] mkdirSync background create failed:", path, e);
+      markLocalOp(resolved);
+      metadataCache.set(resolved, { type: "directory" });
+
+      transport.mkdir(resolved, recursive).catch((e) => {
+        console.error(
+          "[shim:fs] mkdirSync background create failed:",
+          resolved,
+          e,
+        );
       });
     },
 
     rmdirSync(path) {
-      markLocalOp(path);
-      metadataCache.delete(path);
+      const resolved = resolvePath(path);
 
-      transport.rmdir(path).catch((e) => {
-        console.error("[shim:fs] rmdirSync background remove failed:", path, e);
+      markLocalOp(resolved);
+      metadataCache.delete(resolved);
+
+      transport.rmdir(resolved).catch((e) => {
+        console.error(
+          "[shim:fs] rmdirSync background remove failed:",
+          resolved,
+          e,
+        );
       });
     },
 

--- a/packages/shim/src/fs/transport.js
+++ b/packages/shim/src/fs/transport.js
@@ -221,4 +221,52 @@ export const transport = {
       base64: !isText,
     });
   },
+
+  unlinkSync(path) {
+    requestSync("DELETE", "/unlink", { path: normPath(path) });
+  },
+
+  rmdirSync(path) {
+    requestSync("DELETE", "/rmdir", { path: normPath(path) });
+  },
+
+  rmSync(path, recursive) {
+    requestSync("DELETE", "/rm", {
+      path: normPath(path),
+      recursive: recursive ? "true" : "false",
+    });
+  },
+
+  mkdirSync(path, recursive) {
+    requestSync("POST", "/mkdir", { path: normPath(path), recursive });
+  },
+
+  renameSync(oldPath, newPath) {
+    requestSync("POST", "/rename", {
+      oldPath: normPath(oldPath),
+      newPath: normPath(newPath),
+    });
+  },
+
+  copyFileSync(src, dest) {
+    requestSync("POST", "/copyFile", {
+      src: normPath(src),
+      dest: normPath(dest),
+    });
+  },
+
+  appendFileSync(path, content) {
+    requestSync("POST", "/appendFile", {
+      path: normPath(path),
+      content,
+    });
+  },
+
+  utimesSync(path, atime, mtime) {
+    requestSync("POST", "/utimes", {
+      path: normPath(path),
+      atime,
+      mtime,
+    });
+  },
 };

--- a/packages/shim/src/node/stream.js
+++ b/packages/shim/src/node/stream.js
@@ -1,22 +1,23 @@
 import { EventEmitter } from "./events.js";
 
-let warned = false;
-
-function warnNoDataFlow(method) {
-  if (warned) {
-    return;
-  }
-
-  warned = true;
-  console.warn(
-    `[shim:stream] ${method}() called, but stream data flow is not implemented. ` +
-      "This plugin needs the full stream shim.",
-  );
-}
-
 export class Stream extends EventEmitter {
-  pipe(destination) {
-    warnNoDataFlow("pipe");
+  pipe(destination, options) {
+    const end = !options || options.end !== false;
+
+    this.on("data", (chunk) => {
+      const canContinue = destination.write(chunk);
+      if (!canContinue) {
+        this.pause();
+        destination.once("drain", () => this.resume());
+      }
+    });
+
+    if (end) {
+      this.on("end", () => destination.end());
+    }
+
+    this.on("error", (err) => destination.emit("error", err));
+
     return destination;
   }
 }
@@ -26,16 +27,53 @@ export class Readable extends Stream {
     super();
     this.readable = true;
     this._readableState = { options: options || {} };
+    this._paused = false;
+    this._buffer = [];
+    this._ended = false;
   }
 
   read() {
-    warnNoDataFlow("read");
+    if (this._buffer.length > 0) {
+      return this._buffer.shift();
+    }
     return null;
   }
 
-  push() {
-    warnNoDataFlow("push");
-    return false;
+  push(chunk) {
+    if (chunk === null) {
+      this._ended = true;
+      this.emit("end");
+      return false;
+    }
+
+    this._buffer.push(chunk);
+
+    if (!this._paused) {
+      this._flush();
+    }
+
+    return !this._paused;
+  }
+
+  _flush() {
+    while (this._buffer.length > 0 && !this._paused) {
+      const chunk = this._buffer.shift();
+      this.emit("data", chunk);
+    }
+  }
+
+  pause() {
+    this._paused = true;
+    return this;
+  }
+
+  resume() {
+    this._paused = false;
+    this._flush();
+    if (this._ended && this._buffer.length === 0) {
+      this.emit("end");
+    }
+    return this;
   }
 
   _read() {}
@@ -46,15 +84,40 @@ export class Writable extends Stream {
     super();
     this.writable = true;
     this._writableState = { options: options || {} };
+    this._chunks = [];
+    this._finalCalled = false;
   }
 
-  write() {
-    warnNoDataFlow("write");
-    return false;
+  write(chunk, encoding, callback) {
+    if (typeof encoding === "function") {
+      callback = encoding;
+      encoding = undefined;
+    }
+
+    this._chunks.push(chunk);
+    this.emit("drain");
+
+    if (callback) {
+      callback();
+    }
+
+    return true;
   }
 
-  end() {
-    warnNoDataFlow("end");
+  end(chunk, encoding, callback) {
+    if (chunk) {
+      this.write(chunk, encoding);
+    }
+
+    if (!this._finalCalled) {
+      this._finalCalled = true;
+      this.emit("finish");
+    }
+
+    if (callback) {
+      callback();
+    }
+
     return this;
   }
 
@@ -65,15 +128,40 @@ export class Duplex extends Readable {
   constructor(options) {
     super(options);
     this.writable = true;
+    this._chunks = [];
+    this._finalCalled = false;
   }
 
-  write() {
-    warnNoDataFlow("write");
-    return false;
+  write(chunk, encoding, callback) {
+    if (typeof encoding === "function") {
+      callback = encoding;
+      encoding = undefined;
+    }
+
+    this._chunks.push(chunk);
+    this.emit("drain");
+
+    if (callback) {
+      callback();
+    }
+
+    return true;
   }
 
-  end() {
-    warnNoDataFlow("end");
+  end(chunk, encoding, callback) {
+    if (chunk) {
+      this.write(chunk, encoding);
+    }
+
+    if (!this._finalCalled) {
+      this._finalCalled = true;
+      this.emit("finish");
+    }
+
+    if (callback) {
+      callback();
+    }
+
     return this;
   }
 }
@@ -82,4 +170,9 @@ export class Transform extends Duplex {
   _transform() {}
 }
 
-export class PassThrough extends Transform {}
+export class PassThrough extends Transform {
+  _transform(chunk, encoding, callback) {
+    this.push(chunk);
+    if (callback) callback();
+  }
+}


### PR DESCRIPTION
### What problems were encountered

1. **Plugin configuration lost on refresh**: After changing plugin settings in Obsidian, refreshing the page resets them to defaults. The root cause is that `writeFileSync` uses a fire-and-forget pattern — it optimistically updates the in-memory browser cache so Obsidian believes the write succeeded, then fires an async HTTP request to the server without awaiting the response. When the page refreshes, the browser terminates all in-flight requests, and the data never reaches disk.
    
2. **"No permission" error when deleting files**: `rmdirSync` and `mkdirSync` (and their async counterparts) skipped the `resolvePath()` call, causing paths to bypass normalization and registered path transformers. This led to path mismatches with file watcher events, and OS-level `EACCES`/`EPERM` errors from the server were passed through to the frontend.
    
3. **New notes occasionally fail to create**: Same root cause as issue 1 — `writeFileSync` write failures are silently swallowed (only `console.error`). Additionally, the async `readFile` throws `ENOENT` immediately on metadata cache miss without attempting a server request, causing files created by other clients to be falsely reported as missing.
    

### What files were changed

**`packages/shim/src/fs/sync.js`** (3 changes)

- `writeFileSync`: Replaced `transport.writeFile()` (async fetch) with `transport.writeFileSync()` (synchronous XHR), ensuring data reaches the server before the function returns
- `mkdirSync`: Added `const resolved = resolvePath(path)`, consistent with all other file operations
- `rmdirSync`: Same — added `resolvePath()` call

**`packages/shim/src/fs/promises.js`** (3 changes)

- `readFile`: Removed the immediate `ENOENT` throw on metadata cache miss, falling through to `transport.readFile()` for a server request instead
- `mkdir`: Added `const resolved = resolvePath(path)`
- `rmdir`: Same — added `resolvePath()` call

### What effects this brings

- **Plugin settings and note content are no longer lost on page refresh** — data is durably persisted to server disk before `writeFileSync` returns
- **Path consistency for delete and create operations** — `rmdir`/`mkdir` no longer produce spurious permission errors due to unresolved paths
- **Files created by other clients are correctly readable** — async `readFile` no longer falsely reports files as missing when the local cache is stale
- Security posture is unchanged: data still passes through the server's existing path traversal guard and body size limit; synchronous XHR follows the same browser same-origin policy as async fetch