### PR TITLE
0.8.7: direct-fetch allowlist, insecure-context banner, faster boot, websocket keepalive

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,14 @@
+{
+  "rules": {
+    "no-unused-vars": ["warn", { "args": "none" }]
+  },
+  "ignorePatterns": ["**/dist/**"],
+  "overrides": [
+    {
+      "files": ["**/*.svelte"],
+      "rules": {
+        "no-unassigned-vars": "off"
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.7] - Karm (2026-06-18)
+
+### Added
+
+- Direct-fetch host allowlist: hosts the browser fetches directly instead of through the cross-origin proxy, for CORS-friendly hosts.
+- Insecure-context banner: warns when Ignis is served over plain HTTP at a non-localhost origin, where the browser disables crypto and clipboard APIs.
+
+### Changed
+
+- Boot prefetch warms the cache before Obsidian boots; Obsidian's static assets are served immutable.
+- WebSocket heartbeat keeps live-sync connections alive through idle proxies, and the client resyncs its cache on reconnect.
+- Small writes use `fetch` keepalive to survive page dismissal.
+
+### Fixed
+
+- Missing reads are answered from the cache instead of round-tripping.
+- A blocked `window.close()` no longer strands the user on Obsidian's "Saving..." overlay.
+- `mkdir`/`rmdir` resolve their path like other filesystem operations.
+
+### Security
+
+- Server error responses no longer include absolute server paths.
+- `?workspace=` is validated; zip export skips symlinks; demo-mode vault names and quotas are enforced.
+
 ## [0.8.6] - Karm (2026-06-12)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.8.7] - Karm (2026-06-18)
+## [0.8.7] - Karm (2026-06-19)
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,8 @@ If you want to contribute code:
 3. Run `npm run dev` to build and start the server
 4. Test your change in the browser with at least one vault open
 5. Run `npm test` and make sure the whole suite passes
-6. Keep PRs focused - one fix or feature per PR
+6. Run `npm run lint` and make sure it passes
+7. Keep PRs focused, one fix or feature per PR
 
 Changes to deliberate behavior (the fs shim's caching and write model, the proxy's request handling, anything documented as a design decision) start as an issue, not a PR. Open the issue first so the approach can be discussed; a patch against an undiscussed design change will be closed on this basis.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Plugin compatibility depends on what APIs a plugin uses; most plugins built on O
 
 ## Variants
 
-Ignis ships currently ships as a self-hosted server but I have plans for a desktop plugin. The server variant code and Readme with details and setup instructions lives here: [`apps/ignis-server/`](apps/ignis-server/)
+Ignis currently ships as a self-hosted server but I have plans for a desktop plugin. The server variant code and Readme with details and setup instructions lives here: [`apps/ignis-server/`](apps/ignis-server/)
 
 ## What works
 
@@ -41,8 +41,10 @@ Ignis ships currently ships as a self-hosted server but I have plans for a deskt
 - Mobile UI auto-activates when the window is under 600 px wide.
 - Themes and CSS snippets.
 - Most community plugins built on Obsidian's plugin API.
-- Cross-origin plugin requests via `requestUrl` and `fetch`, proxied through the server.
+- Cross-origin plugin requests via `requestUrl` and `fetch`, proxied through the server, or fetched directly for allowlisted CORS-friendly hosts.
 - Obsidian Sync, in self-hosted deployments with a logged-in browser tab open.
+
+**Full functionality requires a secure context (HTTPS, or `localhost`).** Over plain HTTP at a non-localhost origin the browser disables the crypto and clipboard APIs Obsidian needs, breaking graph view, the outline, Sync, and more; Ignis shows a banner. Fix it with HTTPS (a TLS reverse proxy or `tailscale serve`), or for LAN access without TLS, the browser's insecure-origin flag (`#unsafely-treat-insecure-origin-as-secure` in Chromium). See [Secure context (HTTPS)](apps/ignis-server/README.md#secure-context-https).
 
 ## What doesn't work
 
@@ -75,6 +77,7 @@ Compatibility for specific community plugins is tracked in [Issue #9](https://gi
 - Adds a plugin system inside the server itself, separate from Obsidian's community plugin system (WIP).
 - Ignis-specific settings appear as their own tabs inside Obsidian's Settings modal.
 - Server runtime settings (cache sizes, request body limit, etc.) are configurable from the Ignis settings panel.
+- A direct-fetch host allowlist for CORS-friendly hosts the browser fetches directly, bypassing the proxy.
 - Status bar indicators surface server state and headless sync activity.
 
 ## Roadmap

--- a/apps/ignis-server/README.md
+++ b/apps/ignis-server/README.md
@@ -5,6 +5,7 @@ The self-hosted Docker variant of Ignis. For the project overview, feature list,
 ## Contents
 
 - [Authentication](#authentication)
+- [Secure context (HTTPS)](#secure-context-https)
 - [Setup with Docker Compose](#setup-with-docker-compose)
 - [Volumes](#volumes)
 - [Environment Variables](#environment-variables)
@@ -15,6 +16,9 @@ The self-hosted Docker variant of Ignis. For the project overview, feature list,
 ## Authentication
 
 Ignis has **no built-in authentication** and serves plain HTTP by default. Both authentication and TLS termination are expected to be handled by whatever you put in front of it.
+
+> [!IMPORTANT]
+> HTTPS is functionally required, not just for confidentiality. Browser crypto and clipboard APIs are gated to secure contexts, so plain HTTP at a non-localhost origin breaks graph view, the outline, Sync, and more. `localhost` is exempt. See [Secure context (HTTPS)](#secure-context-https).
 
 If you are exposing Ignis to the internet, **you should really** put an authentication layer in front of it. Options include:
 
@@ -28,7 +32,20 @@ Example configurations for Basic Auth and Authelia are in [`examples/`](examples
 > [!CAUTION]
 > Do not run Ignis on a public network without auth. Anyone with the URL can read and write your vault files.
 
-Ignis also runs a cross-origin proxy (`/api/proxy`) that reaches any public host by default. It rejects private, loopback, and link-local addresses, and you can narrow it to an allowlist or disable it entirely from the proxy settings in the Ignis settings panel.
+Ignis also runs a cross-origin proxy (`/api/proxy`) that reaches any public host by default. It rejects private, loopback, and link-local addresses, and you can narrow it to an allowlist or disable it entirely from the proxy settings in the Ignis settings panel. A companion direct-fetch host list (same Settings > Security panel) marks hosts the browser fetches directly instead of through the proxy, for CORS-friendly hosts.
+
+## Secure context (HTTPS)
+
+Browsers only expose the crypto and clipboard APIs Obsidian relies on in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). Served over plain HTTP at a non-localhost origin (a LAN IP or a bare domain), Ignis loses graph view, backlinks, the outline, some clipboard operations, and Sync, and shows a warning banner. `http://localhost` and `http://127.0.0.1` are treated as secure, so a purely local instance is unaffected.
+
+Three ways to get a secure context:
+
+- **A TLS reverse proxy.** Caddy, nginx, Traefik, or any of the [`examples/`](examples) configs. For anything internet-facing.
+- **`tailscale serve`.** Puts HTTPS in front of Ignis on a tailnet with no certificate management. For private remote access.
+- **Mark the origin trusted in the browser.** The most direct fix for LAN access without TLS: tell the browser to treat the Ignis origin as a secure context. No server changes, but per-browser and per-machine, so every client has to set it.
+  - **Chromium (Chrome, Edge, Brave, Opera, Vivaldi):** open `chrome://flags/#unsafely-treat-insecure-origin-as-secure` (Edge and Brave expose the same flag at `edge://flags` and `brave://flags`), set it to **Enabled**, enter the Ignis origin in the box (for example `http://192.168.1.10:8080`; comma-separate several), and relaunch the browser.
+  - **Firefox:** in `about:config`, add the host to `dom.securecontext.allowlist` (comma-separated). Firefox may then try to upgrade sub-resource requests to HTTPS, which can break asset loading, so a reverse proxy is the more reliable option here.
+  - **Safari:** no equivalent flag, safari requires TLS.
 
 ## Setup with Docker Compose
 

--- a/apps/ignis-server/examples/INSTRUCTIONS.md
+++ b/apps/ignis-server/examples/INSTRUCTIONS.md
@@ -122,9 +122,11 @@ Both examples require DNS records pointing to your server:
 
 ### HTTPS
 
+HTTPS is required for full functionality, not just for confidentiality: served over plain HTTP at a non-localhost origin, the browser disables the crypto and clipboard APIs Obsidian relies on, breaking graph view, the outline, clipboard operations, and Sync. Both examples below terminate TLS.
+
 Caddy handles TLS automatically via Let's Encrypt. For this to work, your domain must be publicly resolvable and ports 80/443 must be reachable from the internet (Let's Encrypt needs to verify domain ownership).
 
-If you're running on a local network without public DNS, you can use Caddy's [internal TLS](https://caddyserver.com/docs/caddyfile/directives/tls#internal) to generate self-signed certificates. Add `tls internal` inside each site block in the Caddyfile.
+If you're running on a local network without public DNS, you can use Caddy's [internal TLS](https://caddyserver.com/docs/caddyfile/directives/tls#internal) to generate self-signed certificates. Add `tls internal` inside each site block in the Caddyfile, or use `tailscale serve` to put HTTPS in front of Ignis on a tailnet.
 
 ### Vault data
 

--- a/apps/ignis-server/examples/demo/README.md
+++ b/apps/ignis-server/examples/demo/README.md
@@ -19,6 +19,8 @@ docker compose up -d
 
 The bundled [`docker-compose.yml`](docker-compose.yml) builds Ignis from the parent directory, mounts a 20 MB tmpfs at `/vaults`, and configures the demo limits. Adjust the env vars below for your own deployment.
 
+The compose file serves plain HTTP on `:8080`. Any networked deployment must be fronted by HTTPS (a TLS reverse proxy, `tailscale serve`, etc.) or core obsidian features (graph view, the outline, clipboard, Sync) are disabled and a warning banner is shown; the public demo works because it sits behind HTTPS. Accessing it over `localhost` works since localhost over HTTP is considered a trusted origin by browsers.
+
 ## Demo environment variables
 
 | Variable | Description | Default |

--- a/apps/ignis-server/server/assets/index.html
+++ b/apps/ignis-server/server/assets/index.html
@@ -65,25 +65,67 @@
     }, 250);
   }
 
-  update();
+  function appendScripts() {
+    // No Obsidian scripts to load (markup or scrape mismatch); clear the splash instead of pulsing forever.
+    if (scripts.length === 0) {
+      done();
+      return;
+    }
 
-  for (var i = 0; i < scripts.length; i++) {
-    var s = document.createElement("script");
-    s.type = "text/javascript";
-    s.src = scripts[i];
-    s.async = false;
-    s.onload = function () {
-      loaded++;
-      update();
-      if (loaded === scripts.length) done();
-    };
-    s.onerror = function () {
-      loaded++;
-      update();
-      if (loaded === scripts.length) done();
-    };
-    document.body.appendChild(s);
+    update();
+
+    for (var i = 0; i < scripts.length; i++) {
+      var s = document.createElement("script");
+      s.type = "text/javascript";
+      s.src = scripts[i];
+      s.async = false;
+      s.onload = function () {
+        loaded++;
+        update();
+        if (loaded === scripts.length) done();
+      };
+      s.onerror = function () {
+        loaded++;
+        update();
+        if (loaded === scripts.length) done();
+      };
+      document.body.appendChild(s);
+    }
   }
+
+  // Hold Obsidian's scripts until the shim signals the priority cache slice has landed (window.__ignisBootReady), so Obsidian's early config and plugin reads hit the warm cache.
+  // A timeout proceeds anyway, so a missing or never-resolving promise degrades to loading immediately instead of blocking boot.
+  var ready = window.__ignisBootReady;
+  if (!ready || typeof ready.then !== "function") {
+    appendScripts();
+    return;
+  }
+
+  var started = false;
+
+  function start() {
+    if (started) {
+      return;
+    }
+
+    started = true;
+    // Tell the shim's progress writer to stop touching the splash label now that we own it.
+    window.__ignisBootStarted = true;
+    appendScripts();
+  }
+
+  var timer = setTimeout(start, 3000);
+
+  ready.then(
+    function () {
+      clearTimeout(timer);
+      start();
+    },
+    function () {
+      clearTimeout(timer);
+      start();
+    },
+  );
 })();
 </script>
 </body>

--- a/apps/ignis-server/server/assets/index.html
+++ b/apps/ignis-server/server/assets/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"/>
   <title>Obsidian</title>
-  <link href="app.css" type="text/css" rel="stylesheet"/>
+  <link href="__APP_CSS_SRC__" type="text/css" rel="stylesheet"/>
   <link rel="icon" type="image/png" href="favicon.png"/>
   <link href="assets/overrides.css" type="text/css" rel="stylesheet"/>
   <style>

--- a/apps/ignis-server/server/cache-headers.js
+++ b/apps/ignis-server/server/cache-headers.js
@@ -1,0 +1,30 @@
+// Cache policy for static assets.
+// Versioned requests (carrying a ?v cache-buster) are immutable for a year; unversioned requests keep a short cache and revalidate via ETag.
+
+const IMMUTABLE = "public, max-age=31536000, immutable";
+const SHORT = "public, max-age=300";
+
+// Asset types whose caching we manage; everything else keeps express.static defaults.
+const ASSET_EXT = /\.(?:js|css|woff2?|ttf|otf|wasm|map)$/i;
+
+// Append a version query so an upgrade busts the immutable cache.
+// Returns the src unchanged when there is no version, so nothing is pinned against a bogus value.
+function versionedSrc(src, version) {
+  if (!version) {
+    return src;
+  }
+
+  return src + (src.includes("?") ? "&" : "?") + "v=" + version;
+}
+
+// Cache-Control for a static asset request, or null to leave it to express.static.
+// Only versioned URLs carry ?v, and they are version-busted on upgrade, so immutable is safe.
+function cacheControlFor(reqPath, hasVersion) {
+  if (!ASSET_EXT.test(reqPath)) {
+    return null;
+  }
+
+  return hasVersion ? IMMUTABLE : SHORT;
+}
+
+module.exports = { versionedSrc, cacheControlFor };

--- a/apps/ignis-server/server/cache-headers.test.mjs
+++ b/apps/ignis-server/server/cache-headers.test.mjs
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { versionedSrc, cacheControlFor } = require("./cache-headers.js");
+
+describe("versionedSrc", () => {
+  it("appends ?v when the src has no query", () => {
+    expect(versionedSrc("app.js", "1.12.7")).toBe("app.js?v=1.12.7");
+  });
+
+  it("appends &v when the src already has a query", () => {
+    expect(versionedSrc("a.js?x=1", "1.12.7")).toBe("a.js?x=1&v=1.12.7");
+  });
+
+  it("leaves the src unchanged when the version is missing", () => {
+    expect(versionedSrc("app.js", null)).toBe("app.js");
+  });
+});
+
+describe("cacheControlFor", () => {
+  it("is immutable for a versioned asset", () => {
+    expect(cacheControlFor("/app.js", true)).toBe(
+      "public, max-age=31536000, immutable",
+    );
+  });
+
+  it("is a short cache for an unversioned asset", () => {
+    expect(cacheControlFor("/app.js", false)).toBe("public, max-age=300");
+  });
+
+  it("covers css, fonts, wasm, and sourcemaps", () => {
+    for (const p of ["/app.css", "/x.woff2", "/x.ttf", "/x.wasm", "/x.js.map"]) {
+      expect(cacheControlFor(p, true)).toContain("immutable");
+    }
+  });
+
+  it("leaves unmanaged paths to express.static", () => {
+    expect(cacheControlFor("/api/bootstrap", false)).toBeNull();
+    expect(cacheControlFor("/image.png", true)).toBeNull();
+    expect(cacheControlFor("/", false)).toBeNull();
+  });
+});

--- a/apps/ignis-server/server/config.js
+++ b/apps/ignis-server/server/config.js
@@ -90,9 +90,8 @@ module.exports = {
     path.join(REPO_ROOT, "investigation", "obsidian_1.12.7_unpacked"),
 
   get obsidianVersion() {
-    const assetsPath =
-      process.env.OBSIDIAN_ASSETS_PATH ||
-      path.join(__dirname, "..", "investigation", "obsidian_1.12.7_unpacked");
+    // Read from the same path the assets are served from, so the version matches what ships.
+    const assetsPath = this.obsidianAssetsPath;
     try {
       const pkg = JSON.parse(
         fs.readFileSync(path.join(assetsPath, "package.json"), "utf-8"),

--- a/apps/ignis-server/server/demo/demo-cleanup.js
+++ b/apps/ignis-server/server/demo/demo-cleanup.js
@@ -64,6 +64,7 @@ async function cleanupExpired() {
   }
 
   // Correct optimistic-quota drift for the sessions that remain (copyFile and mkdir add bytes the per-request quota gate does not count).
+  // eslint-disable-next-line unicorn/no-useless-spread
   for (const sessionId of [...sessions.keys()]) {
     await recomputeBytes(sessionId);
   }

--- a/apps/ignis-server/server/demo/demo-cleanup.js
+++ b/apps/ignis-server/server/demo/demo-cleanup.js
@@ -13,6 +13,7 @@ const {
   makeStorageName,
   PREFIX_SEPARATOR,
 } = require("./demo-sessions");
+const { recomputeBytes } = require("./demo-provision");
 
 async function cleanupSession(sessionId) {
   const s = sessions.get(sessionId);
@@ -60,6 +61,11 @@ async function cleanupExpired() {
 
   for (const sessionId of expired) {
     await cleanupSession(sessionId);
+  }
+
+  // Correct optimistic-quota drift for the sessions that remain (copyFile and mkdir add bytes the per-request quota gate does not count).
+  for (const sessionId of [...sessions.keys()]) {
+    await recomputeBytes(sessionId);
   }
 
   // Orphan scan: directories matching demo-* whose session is gone

--- a/apps/ignis-server/server/demo/demo-middleware.js
+++ b/apps/ignis-server/server/demo/demo-middleware.js
@@ -18,6 +18,7 @@ const {
   touchSession,
 } = require("./demo-sessions");
 const { ensureDefaultVault } = require("./demo-provision");
+const { sanitizeError } = require("@ignis/server-core");
 
 const ALLOWED_PROXY_HOSTS = new Set([
   "releases.obsidian.md",
@@ -406,7 +407,7 @@ function provisionEndpoint(req, res) {
     })
     .catch((e) => {
       console.error("[demo] provision error:", e);
-      res.status(500).json({ error: e.message });
+      res.status(500).json(sanitizeError(e));
     });
 }
 

--- a/apps/ignis-server/server/demo/demo-middleware.js
+++ b/apps/ignis-server/server/demo/demo-middleware.js
@@ -10,6 +10,8 @@ const {
   sessions,
   makeStorageName,
   tryParseUserVaultName,
+  isValidUserVaultName,
+  stripStoragePrefix,
   parseCookies,
   setSessionCookie,
   getOrCreateSession,
@@ -74,6 +76,10 @@ function inboundTranslator(req, res, next) {
 
     // Vault create/rename pass the new name as `name`
     if (req.body.name && (req.path === "/create" || req.path === "/rename")) {
+      if (!isValidUserVaultName(req.body.name)) {
+        return res.status(400).json({ error: "Invalid vault name" });
+      }
+
       req.body.name = makeStorageName(sessionId, req.body.name);
     }
   }
@@ -108,8 +114,7 @@ function outboundTranslator(req, res, next) {
 
   // clean path for UI display.
   const prefix = "demo-" + sessionId + "__";
-  const stripPrefix = (s) =>
-    typeof s === "string" ? s.split(prefix).join("") : s;
+  const stripPrefix = (s) => stripStoragePrefix(s, prefix);
 
   res.json = function (body) {
     if (Array.isArray(body)) {
@@ -192,7 +197,10 @@ function vaultsPerSessionEnforcer(req, res, next) {
 }
 
 function quotaEnforcer(req, res, next) {
-  if (req.path !== "/writeFile" || req.method !== "POST") {
+  if (
+    req.method !== "POST" ||
+    (req.path !== "/writeFile" && req.path !== "/appendFile")
+  ) {
     return next();
   }
 

--- a/apps/ignis-server/server/demo/demo-sessions.js
+++ b/apps/ignis-server/server/demo/demo-sessions.js
@@ -41,6 +41,22 @@ function tryParseUserVaultName(sessionId, storageName) {
   return null;
 }
 
+// Strip the session storage prefix from a value such as a vault path.
+function stripStoragePrefix(value, prefix) {
+  return typeof value === "string" ? value.replace(prefix, "") : value;
+}
+
+// User-visible demo vault names must not collide with the storage-prefix scheme, or the prefix strip on the way back out mangles them.
+function isValidUserVaultName(name) {
+  return (
+    typeof name === "string" &&
+    name.length > 0 &&
+    name.length <= 64 &&
+    !name.includes(PREFIX_SEPARATOR) &&
+    !name.startsWith("demo-")
+  );
+}
+
 function parseCookies(req) {
   const header = req.headers.cookie;
 
@@ -131,6 +147,8 @@ module.exports = {
   prefixFor,
   makeStorageName,
   tryParseUserVaultName,
+  isValidUserVaultName,
+  stripStoragePrefix,
   parseCookies,
   setSessionCookie,
   getOrCreateSession,

--- a/apps/ignis-server/server/demo/demo-sessions.test.mjs
+++ b/apps/ignis-server/server/demo/demo-sessions.test.mjs
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { isValidUserVaultName, stripStoragePrefix } = require(
+  "./demo-sessions.js",
+);
+
+describe("isValidUserVaultName", () => {
+  it("accepts a normal user vault name", () => {
+    expect(isValidUserVaultName("My Notes")).toBe(true);
+    expect(isValidUserVaultName("vault-1.bak")).toBe(true);
+  });
+
+  it("rejects names that collide with the storage-prefix scheme", () => {
+    expect(isValidUserVaultName("a__b")).toBe(false);
+    expect(isValidUserVaultName("demo-foo")).toBe(false);
+  });
+
+  it("rejects empty, non-string, and over-long names", () => {
+    expect(isValidUserVaultName("")).toBe(false);
+    expect(isValidUserVaultName(null)).toBe(false);
+    expect(isValidUserVaultName(undefined)).toBe(false);
+    expect(isValidUserVaultName("x".repeat(65))).toBe(false);
+  });
+});
+
+describe("stripStoragePrefix", () => {
+  const prefix = "demo-abc123__";
+
+  it("strips the prefix where it is embedded mid-path", () => {
+    expect(stripStoragePrefix("/vaults/demo-abc123__Notes", prefix)).toBe(
+      "/vaults/Notes",
+    );
+  });
+
+  it("leaves a value without the prefix unchanged", () => {
+    expect(stripStoragePrefix("/vaults/Notes", prefix)).toBe("/vaults/Notes");
+  });
+
+  it("passes non-strings through", () => {
+    expect(stripStoragePrefix(undefined, prefix)).toBe(undefined);
+  });
+});

--- a/apps/ignis-server/server/index.js
+++ b/apps/ignis-server/server/index.js
@@ -5,6 +5,7 @@ const compression = require("compression");
 const config = require("./config");
 const settings = require("./settings");
 const { getVersion } = require("./version");
+const { versionedSrc, cacheControlFor } = require("./cache-headers");
 const {
   setupWebSocket,
   watcher,
@@ -138,13 +139,22 @@ function buildIndexHtml() {
     scripts.push(match[1]);
   }
 
+  // Version Obsidian's assets by the Obsidian version so an upgrade busts their immutable cache.
+  // Omitted when the version is unknown, so nothing is pinned immutable against a wrong version.
+  const ov = config.obsidianVersion;
+  const obsidianVersion = ov && ov !== "0.0.0" ? ov : null;
+
   // Build from our own template
   const templatePath = path.join(__dirname, "assets", "index.html");
   let html = fs.readFileSync(templatePath, "utf-8");
 
   html = html.replace("__IGNIS_UI_SRC__", `ignis-ui.js?v=${version}`);
   html = html.replace("__SHIM_LOADER_SRC__", `shim-loader.js?v=${version}`);
-  html = html.replace("__OBSIDIAN_SCRIPTS__", JSON.stringify(scripts));
+  html = html.replace("__APP_CSS_SRC__", versionedSrc("app.css", obsidianVersion));
+  html = html.replace(
+    "__OBSIDIAN_SCRIPTS__",
+    JSON.stringify(scripts.map((s) => versionedSrc(s, obsidianVersion))),
+  );
 
   if (config.demoMode) {
     html = html.replace(
@@ -167,17 +177,15 @@ app.get("/favicon.png", (req, res) => {
   res.sendFile(path.join(REPO_ROOT, "images", "favicon.png"));
 });
 
-// Serve dist files with cache headers based on version param
+// Cache headers for static assets, by version query.
+// Set before express.static, which only fills Cache-Control when it is not already present.
 app.use((req, res, next) => {
-  if (req.path.match(/\/(ignis-ui|shim-loader)\.js$/)) {
-    if (req.query.v) {
-      // Versioned assets - cache for 1 year
-      res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
-    } else {
-      // No version param - short cache for dev/fallback
-      res.setHeader("Cache-Control", "public, max-age=300");
-    }
+  const cacheControl = cacheControlFor(req.path, !!req.query.v);
+
+  if (cacheControl) {
+    res.setHeader("Cache-Control", cacheControl);
   }
+
   next();
 });
 

--- a/apps/ignis-server/server/plugin-system/manager.js
+++ b/apps/ignis-server/server/plugin-system/manager.js
@@ -63,7 +63,7 @@ async function initPlugins(ctx) {
 async function shutdownPlugins() {
   console.log("[plugins] Shutting down all plugins...");
 
-  for (const [pluginId, loaded] of loadedPlugins) {
+  for (const loaded of loadedPlugins.values()) {
     if (loaded.shutdown) {
       try {
         console.log(`[plugins] Shutting down: ${loaded.name}`);

--- a/apps/ignis-server/server/plugins/headless-sync/obsidian/src/settings-tab.js
+++ b/apps/ignis-server/server/plugins/headless-sync/obsidian/src/settings-tab.js
@@ -52,7 +52,7 @@ class HeadlessSyncSettingTab extends PluginSettingTab {
 
     try {
       serverStatus = await api.getStatus();
-    } catch (e) {
+    } catch {
       containerEl.createEl("p", {
         text: "Failed to connect to Headless Sync server plugin.",
         cls: "mod-warning",

--- a/apps/ignis-server/server/plugins/headless-sync/routes.js
+++ b/apps/ignis-server/server/plugins/headless-sync/routes.js
@@ -1,5 +1,6 @@
 const auth = require("./auth");
 const obCli = require("./ob-cli");
+const { sanitizeError } = require("@ignis/server-core");
 
 function mountRoutes(router, plugin) {
   router.get("/status", (req, res) => {
@@ -31,7 +32,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true });
     } catch (e) {
       ctx.log(`Login failed: ${e.message}`);
-      res.status(500).json({ error: e.code || "internal" });
+      res.status(500).json(sanitizeError(e));
     }
   });
 
@@ -44,7 +45,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true });
     } catch (e) {
       ctx.log(`Logout failed: ${e.message}`);
-      res.status(500).json({ error: e.code || "internal" });
+      res.status(500).json(sanitizeError(e));
     }
   });
 
@@ -78,7 +79,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true, state });
     } catch (e) {
       ctx.log(`Failed to setup sync: ${e.message}`);
-      res.status(500).json({ error: e.code || "internal" });
+      res.status(500).json(sanitizeError(e));
     }
   });
 
@@ -96,7 +97,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true, state });
     } catch (e) {
       ctx.log(`Failed to start sync: ${e.message}`);
-      res.status(500).json({ error: e.code || "internal" });
+      res.status(500).json(sanitizeError(e));
     }
   });
 
@@ -114,7 +115,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true, state });
     } catch (e) {
       ctx.log(`Failed to stop sync: ${e.message}`);
-      res.status(500).json({ error: e.code || "internal" });
+      res.status(500).json(sanitizeError(e));
     }
   });
 
@@ -132,7 +133,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true });
     } catch (e) {
       ctx.log(`Failed to unlink vault: ${e.message}`);
-      res.status(500).json({ error: e.code || "internal" });
+      res.status(500).json(sanitizeError(e));
     }
   });
 
@@ -185,7 +186,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true });
     } catch (e) {
       ctx.log(`Failed to create remote vault: ${e.message}`);
-      res.status(500).json({ error: e.code || "internal" });
+      res.status(500).json(sanitizeError(e));
     }
   });
 
@@ -202,7 +203,7 @@ function mountRoutes(router, plugin) {
       res.json({ vaults });
     } catch (e) {
       ctx.log(`Failed to list remote vaults: ${e.message}`);
-      res.status(500).json({ error: e.code || "internal" });
+      res.status(500).json(sanitizeError(e));
     }
   });
 }

--- a/apps/ignis-server/server/plugins/headless-sync/routes.js
+++ b/apps/ignis-server/server/plugins/headless-sync/routes.js
@@ -30,7 +30,8 @@ function mountRoutes(router, plugin) {
       ctx.log(`Auth token saved${email ? ` for ${email}` : ""}`);
       res.json({ success: true });
     } catch (e) {
-      res.status(500).json({ error: e.message });
+      ctx.log(`Login failed: ${e.message}`);
+      res.status(500).json({ error: e.code || "internal" });
     }
   });
 
@@ -42,7 +43,8 @@ function mountRoutes(router, plugin) {
       ctx.log("Auth token cleared");
       res.json({ success: true });
     } catch (e) {
-      res.status(500).json({ error: e.message });
+      ctx.log(`Logout failed: ${e.message}`);
+      res.status(500).json({ error: e.code || "internal" });
     }
   });
 
@@ -76,7 +78,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true, state });
     } catch (e) {
       ctx.log(`Failed to setup sync: ${e.message}`);
-      res.status(500).json({ error: e.message });
+      res.status(500).json({ error: e.code || "internal" });
     }
   });
 
@@ -94,7 +96,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true, state });
     } catch (e) {
       ctx.log(`Failed to start sync: ${e.message}`);
-      res.status(500).json({ error: e.message });
+      res.status(500).json({ error: e.code || "internal" });
     }
   });
 
@@ -112,7 +114,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true, state });
     } catch (e) {
       ctx.log(`Failed to stop sync: ${e.message}`);
-      res.status(500).json({ error: e.message });
+      res.status(500).json({ error: e.code || "internal" });
     }
   });
 
@@ -130,7 +132,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true });
     } catch (e) {
       ctx.log(`Failed to unlink vault: ${e.message}`);
-      res.status(500).json({ error: e.message });
+      res.status(500).json({ error: e.code || "internal" });
     }
   });
 
@@ -183,7 +185,7 @@ function mountRoutes(router, plugin) {
       res.json({ success: true });
     } catch (e) {
       ctx.log(`Failed to create remote vault: ${e.message}`);
-      res.status(500).json({ error: e.message });
+      res.status(500).json({ error: e.code || "internal" });
     }
   });
 
@@ -200,7 +202,7 @@ function mountRoutes(router, plugin) {
       res.json({ vaults });
     } catch (e) {
       ctx.log(`Failed to list remote vaults: ${e.message}`);
-      res.status(500).json({ error: e.message });
+      res.status(500).json({ error: e.code || "internal" });
     }
   });
 }

--- a/apps/ignis-server/server/plugins/headless-sync/sync-manager.js
+++ b/apps/ignis-server/server/plugins/headless-sync/sync-manager.js
@@ -66,7 +66,7 @@ class SyncManager {
   saveStates() {
     const data = [];
 
-    for (const [vaultId, state] of this.states) {
+    for (const state of this.states.values()) {
       data.push({
         vaultId: state.vaultId,
         vaultPath: state.vaultPath,

--- a/apps/ignis-server/server/routes/bootstrap.js
+++ b/apps/ignis-server/server/routes/bootstrap.js
@@ -15,6 +15,7 @@ const {
 } = require("../plugin-system/manager");
 const { getVersion } = require("../version");
 const settings = require("../settings");
+const { sanitizeError } = require("@ignis/server-core");
 
 const router = express.Router();
 
@@ -255,7 +256,7 @@ router.get("/", async (req, res) => {
     res.json(entry.response);
   } catch (e) {
     console.error("[bootstrap] error:", e);
-    res.status(500).json({ error: e.code || "internal" });
+    res.status(500).json(sanitizeError(e));
   }
 });
 

--- a/apps/ignis-server/server/routes/bootstrap.js
+++ b/apps/ignis-server/server/routes/bootstrap.js
@@ -255,7 +255,7 @@ router.get("/", async (req, res) => {
     res.json(entry.response);
   } catch (e) {
     console.error("[bootstrap] error:", e);
-    res.status(500).json({ error: e.message });
+    res.status(500).json({ error: e.code || "internal" });
   }
 });
 

--- a/apps/ignis-server/server/routes/bootstrap.js
+++ b/apps/ignis-server/server/routes/bootstrap.js
@@ -146,6 +146,7 @@ async function buildEntry(vaultId) {
       contentCacheBytes: settings.get("contentCacheBytes"),
       inputCacheBytes: settings.get("inputCacheBytes"),
       inputCacheTtlMs: settings.get("inputCacheTtlMs"),
+      directFetchHosts: settings.get("directFetchHosts"),
     },
   };
 

--- a/apps/ignis-server/server/routes/fs.js
+++ b/apps/ignis-server/server/routes/fs.js
@@ -7,6 +7,7 @@ const {
   writeCoalescer,
   encodeContentDispositionFilename,
   resolveVaultPath,
+  sanitizeError,
 } = require("@ignis/server-core");
 const { writeCoalesced, getPending } = writeCoalescer;
 const bootstrapRoutes = require("./bootstrap");
@@ -98,7 +99,7 @@ router.get("/stat", async (req, res) => {
   } catch (e) {
     res
       .status(e.code === "ENOENT" ? 404 : 500)
-      .json({ error: e.code || "internal", code: e.code });
+      .json(sanitizeError(e));
   }
 });
 
@@ -133,7 +134,7 @@ router.get("/readdir", async (req, res) => {
   } catch (e) {
     res
       .status(e.code === "ENOENT" ? 404 : 500)
-      .json({ error: e.code || "internal", code: e.code });
+      .json(sanitizeError(e));
   }
 });
 
@@ -184,7 +185,7 @@ router.get("/readFile", async (req, res) => {
   } catch (e) {
     res
       .status(e.code === "ENOENT" ? 404 : 500)
-      .json({ error: e.code || "internal", code: e.code });
+      .json(sanitizeError(e));
   }
 });
 
@@ -213,7 +214,7 @@ router.post("/writeFile", async (req, res) => {
     invalidateBootstrap(req);
     res.json({ ok: true, mtime: result.mtime, size: result.size });
   } catch (e) {
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -231,7 +232,7 @@ router.post("/appendFile", async (req, res) => {
     invalidateBootstrap(req);
     res.json({ ok: true });
   } catch (e) {
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -251,7 +252,7 @@ router.post("/mkdir", async (req, res) => {
     invalidateBootstrap(req);
     res.json({ ok: true });
   } catch (e) {
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -280,7 +281,7 @@ router.post("/rename", async (req, res) => {
     invalidateBootstrap(req);
     res.json({ ok: true });
   } catch (e) {
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -309,7 +310,7 @@ router.post("/copyFile", async (req, res) => {
     invalidateBootstrap(req);
     res.json({ ok: true });
   } catch (e) {
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -331,7 +332,7 @@ router.delete("/unlink", async (req, res) => {
       // File already gone  -  desired outcome achieved
       res.json({ ok: true });
     } else {
-      res.status(500).json({ error: e.code || "internal", code: e.code });
+      res.status(500).json(sanitizeError(e));
     }
   }
 });
@@ -350,7 +351,7 @@ router.delete("/rmdir", async (req, res) => {
     invalidateBootstrap(req);
     res.json({ ok: true });
   } catch (e) {
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -370,7 +371,7 @@ router.delete("/rm", async (req, res) => {
     invalidateBootstrap(req);
     res.json({ ok: true });
   } catch (e) {
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -388,7 +389,7 @@ router.get("/access", async (req, res) => {
   } catch (e) {
     res
       .status(e.code === "ENOENT" ? 404 : 500)
-      .json({ error: e.code || "internal", code: e.code });
+      .json(sanitizeError(e));
   }
 });
 
@@ -410,7 +411,7 @@ router.post("/utimes", async (req, res) => {
     invalidateBootstrap(req);
     res.json({ ok: true });
   } catch (e) {
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -520,7 +521,7 @@ router.get("/tree", async (req, res) => {
 
     res.json(tree);
   } catch (e) {
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -550,7 +551,7 @@ router.get("/download", async (req, res) => {
   } catch (e) {
     res
       .status(e.code === "ENOENT" ? 404 : 500)
-      .json({ error: e.code || "internal", code: e.code });
+      .json(sanitizeError(e));
   }
 });
 
@@ -591,7 +592,7 @@ router.get("/download-zip", async (req, res) => {
   } catch (e) {
     res
       .status(e.code === "ENOENT" ? 404 : 500)
-      .json({ error: e.code || "internal", code: e.code });
+      .json(sanitizeError(e));
   }
 });
 

--- a/apps/ignis-server/server/routes/fs.js
+++ b/apps/ignis-server/server/routes/fs.js
@@ -583,7 +583,10 @@ router.get("/download-zip", async (req, res) => {
     });
 
     archive.pipe(res);
-    archive.directory(resolved, folderName);
+    // Skip symlinked entries so the zip cannot carry a link that escapes the vault on extraction.
+    archive.directory(resolved, folderName, (entry) =>
+      entry.stats && entry.stats.isSymbolicLink() ? false : entry,
+    );
     archive.finalize();
   } catch (e) {
     res

--- a/apps/ignis-server/server/routes/plugins.js
+++ b/apps/ignis-server/server/routes/plugins.js
@@ -4,6 +4,7 @@ const {
   enablePluginForVault,
   disablePluginForVault,
 } = require("../plugin-system/manager");
+const { sanitizeError } = require("@ignis/server-core");
 
 const router = express.Router();
 
@@ -22,7 +23,7 @@ router.post("/:pluginId/enable", async (req, res) => {
     await enablePluginForVault(req.params.pluginId, vaultId);
     res.json({ ok: true });
   } catch (e) {
-    res.status(400).json({ error: e.message });
+    res.status(400).json(sanitizeError(e));
   }
 });
 
@@ -37,7 +38,7 @@ router.post("/:pluginId/disable", async (req, res) => {
     await disablePluginForVault(req.params.pluginId, vaultId);
     res.json({ ok: true });
   } catch (e) {
-    res.status(400).json({ error: e.message });
+    res.status(400).json(sanitizeError(e));
   }
 });
 

--- a/apps/ignis-server/server/routes/proxy.js
+++ b/apps/ignis-server/server/routes/proxy.js
@@ -5,6 +5,7 @@ const http = require("http");
 const https = require("https");
 const zlib = require("zlib");
 const settings = require("../settings");
+const { sanitizeError } = require("@ignis/server-core");
 
 const router = express.Router();
 
@@ -360,6 +361,7 @@ router.post("/", async (req, res) => {
   try {
     await assertPublicUrl(url);
   } catch (e) {
+    // assertPublicUrl throws deliberate, safe guard messages (blocked host, bad scheme); don't use sanitizeError.
     return res.status(e.statusCode || 400).json({ error: e.message });
   }
 
@@ -418,7 +420,7 @@ router.post("/", async (req, res) => {
       body: respBody.toString("base64"),
     });
   } catch (e) {
-    res.status(e.statusCode || 502).json({ error: e.message });
+    res.status(e.statusCode || 502).json(sanitizeError(e));
   }
 });
 

--- a/apps/ignis-server/server/routes/proxy.js
+++ b/apps/ignis-server/server/routes/proxy.js
@@ -362,6 +362,7 @@ router.post("/", async (req, res) => {
     await assertPublicUrl(url);
   } catch (e) {
     // assertPublicUrl throws deliberate, safe guard messages (blocked host, bad scheme); don't use sanitizeError.
+    // leak-allow
     return res.status(e.statusCode || 400).json({ error: e.message });
   }
 

--- a/apps/ignis-server/server/routes/settings.js
+++ b/apps/ignis-server/server/routes/settings.js
@@ -82,6 +82,7 @@ router.post("/", (req, res) => {
     clean = validate(req.body || {});
   } catch (e) {
     // validate() throws deliberate, safe messages naming the invalid setting; don't use sanitizeError.
+    // leak-allow
     return res.status(400).json({ error: e.message });
   }
 

--- a/apps/ignis-server/server/routes/settings.js
+++ b/apps/ignis-server/server/routes/settings.js
@@ -81,6 +81,7 @@ router.post("/", (req, res) => {
   try {
     clean = validate(req.body || {});
   } catch (e) {
+    // validate() throws deliberate, safe messages naming the invalid setting; don't use sanitizeError.
     return res.status(400).json({ error: e.message });
   }
 

--- a/apps/ignis-server/server/routes/settings.js
+++ b/apps/ignis-server/server/routes/settings.js
@@ -12,7 +12,7 @@ const NUMBER_KEYS = [
   "writeCoalesceMs",
   "maxBodyBytes",
 ];
-const LIST_KEYS = ["proxyAllowlist"];
+const LIST_KEYS = ["proxyAllowlist", "directFetchHosts"];
 
 function validate(body) {
   const clean = {};

--- a/apps/ignis-server/server/routes/settings.test.mjs
+++ b/apps/ignis-server/server/routes/settings.test.mjs
@@ -32,6 +32,12 @@ describe("settings validate", () => {
     ).toEqual({ proxyAllowlist: ["api.example.com", "github.com"] });
   });
 
+  it("trims a valid direct-fetch host list", () => {
+    expect(
+      validate({ directFetchHosts: [" api.example.com ", "imt.example.com"] }),
+    ).toEqual({ directFetchHosts: ["api.example.com", "imt.example.com"] });
+  });
+
   it("rejects a non-array allowlist or an empty entry", () => {
     expect(() => validate({ proxyAllowlist: "x" })).toThrow();
     expect(() => validate({ proxyAllowlist: ["ok", "  "] })).toThrow();

--- a/apps/ignis-server/server/routes/vault.js
+++ b/apps/ignis-server/server/routes/vault.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const config = require("../config");
 const path = require("path");
 const bootstrapRoutes = require("./bootstrap");
+const { sanitizeError } = require("@ignis/server-core");
 
 const router = express.Router();
 
@@ -81,7 +82,7 @@ router.post("/create", async (req, res) => {
       return res.status(409).json({ error: "Vault already exists" });
     }
 
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -117,7 +118,7 @@ router.post("/rename", async (req, res) => {
         .json({ error: "A vault with that name already exists" });
     }
 
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 
@@ -138,7 +139,7 @@ router.delete("/remove", async (req, res) => {
 
     res.json({ ok: true });
   } catch (e) {
-    res.status(500).json({ error: e.code || "internal", code: e.code });
+    res.status(500).json(sanitizeError(e));
   }
 });
 

--- a/apps/ignis-server/server/routes/vault.js
+++ b/apps/ignis-server/server/routes/vault.js
@@ -15,7 +15,7 @@ function isValidVaultName(name) {
     return false;
   }
 
-  if (/[\/\\:*?"<>|]/.test(name)) {
+  if (/[/\\:*?"<>|]/.test(name)) {
     return false;
   }
 

--- a/apps/ignis-server/server/settings.js
+++ b/apps/ignis-server/server/settings.js
@@ -16,6 +16,8 @@ const DEFAULTS = {
   proxyMode: "any",
   // Empty allows any public host.
   proxyAllowlist: [],
+  // Hosts the browser fetches directly instead of through the proxy; they must send permissive CORS.
+  directFetchHosts: [],
   wsOrigins: [],
   // Private IPs/CIDRs the proxy may reach despite the SSRF guard.
   proxyAllowPrivate: [],

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,11 +44,11 @@ The shim layer makes Obsidian think it's running in Electron. The bridge adds Ig
 
 ### Loading
 
-The server serves its own `index.html` (in `apps/ignis-server/server/assets/`) rather than Obsidian's. At startup it reads Obsidian's `index.html` once to discover which scripts Obsidian expects, then embeds that list in our HTML as a JSON array. The client-side HTML loads the shim loader and UI bundle first (non-deferred), then a small inline script dynamically injects Obsidian's scripts in order. Obsidian's files are never modified on disk, or transformed in transit.
+The server serves its own `index.html` (in `apps/ignis-server/server/assets/`) rather than Obsidian's. At startup it reads Obsidian's `index.html` once to discover which scripts Obsidian expects, then embeds that list in our HTML as a JSON array. The client-side HTML loads the shim loader and UI bundle first (non-deferred), then a small inline script dynamically injects Obsidian's scripts in order. The injected asset URLs (`app.js`, `app.css`, `lib/*`) are versioned by the pinned Obsidian version and served immutable, so the browser and any CDN edge hold the bundle across loads instead of re-pulling it. Obsidian's files are never modified on disk, or transformed in transit.
 
 Before injecting Obsidian's scripts, the shim loader sets `localStorage.EmulateMobile` based on viewport width (< 600px) so Obsidian boots into its mobile UI on phones and narrow windows. The loader replaces the module system, then issues a single blocking bootstrap request that returns the vault info, vault list, metadata tree, and Ignis plugin list in one pre-compressed response. The request has to be blocking because Obsidian makes synchronous filesystem calls during page load, before the event loop is running, so the cache has to already be populated.
 
-Immediately after the bootstrap response is applied, the client kicks off a batched pre-fetch of text file content into the ContentCache (`POST /api/fs/batch-read`). This races Obsidian's indexer so the first wave of `readFile` calls during startup indexing tend to hit the cache instead of the network.
+Immediately after the bootstrap response is applied, the client prefetches file content into the ContentCache (`POST /api/fs/batch-read`), split into two slices. A priority slice (the `.obsidian` root configs plus each plugin's `main.js`, `manifest.json`, and `styles.css`) is awaited before Obsidian's scripts are injected, so Obsidian's synchronous boot reads hit the cache rather than the network. A bulk slice of the remaining text content streams afterward without blocking boot. The boot splash reflects prefetch progress.
 
 ### Modules
 
@@ -58,7 +58,7 @@ Immediately after the bootstrap response is applied, the client kicks off a batc
 | `path`               | path-browserify                                                                                 |
 | `url`                | Browser URL API wrapper                                                                         |
 | `process`            | Platform/version stubs                                                                          |
-| `crypto`             | `randomBytes`, `randomUUID`, `scrypt` use Web Crypto. `createHash` produces real digests for SHA-1/SHA-256/SHA-512/MD5 via `@noble/hashes`. |
+| `crypto`             | `randomBytes`, `randomUUID`, `scrypt` use Web Crypto. `createHash` produces real digests for SHA-1/SHA-256/SHA-512/MD5 via `@noble/hashes`. Web Crypto needs a secure context; on plain HTTP at a non-localhost origin it is unavailable and the UI shows an insecure-context banner. |
 | `electron`           | `ipcRenderer` dispatcher, `webFrame` stubs, `clipboard`, `nativeImage`, `safeStorage` (passthrough, reports unavailable). |
 | `@electron/remote`   | Partial: `clipboard`, `shell`, `dialog` (with a sync file picker workaround), `Menu`, `BrowserWindow`, `nativeTheme`, `session`, `systemPreferences`, `screen`, `nativeImage`, `Notification`, `app`. |
 | `zlib`               | Sync + callback variants via pako (`deflate`, `inflate`, `gzip`, `gunzip`, raw). Streaming classes (`createGzip` etc.) throw. |
@@ -97,13 +97,13 @@ All hooks are synchronous and registered at module load. They fire once at the s
 
 Electron's `ipcRenderer` is the renderer's channel to the main process for things only that process can do: looking up the active vault, opening a new vault window, performing cross-origin requests, printing to PDF. Ignis has no main process, so the shim is an in-process router that returns values for sync calls and fires side effects for async ones.
 
-Sync channels covered include `vault`, `version`, `vault-list`, `vault-open`, `vault-remove`, `file-url`, `starter`, and `help`. Each maps to a handler that returns immediately. Async channels: `request-url` is routed to the CORS proxy, `print-to-pdf` triggers a hidden popup iframe, `context-menu` replies on the next tick. The standard `on`/`once`/`removeListener` interface works as it would in Electron.
+Sync channels covered include `vault`, `version`, `vault-list`, `vault-open`, `vault-remove`, `file-url`, `starter`, and `help`. Each maps to a handler that returns immediately. Async channels: `request-url` is routed to the CORS proxy (or fetched directly when the host is on the direct-fetch allowlist), `print-to-pdf` triggers a hidden popup iframe, `context-menu` replies on the next tick. The standard `on`/`once`/`removeListener` interface works as it would in Electron.
 
 ### Cross-origin requests
 
 Obsidian on the desktop can make arbitrary cross-origin HTTP requests because it runs as an Electron app rather than a sandboxed browser context. In a browser tab, the same requests would be blocked by CORS or rejected by the same-origin policy. Plugin installs from GitHub, theme asset downloads, calls to third-party APIs: all of it assumes cross-origin is available.
 
-The shim handles this transparently. `window.fetch` and `window.requestUrl` are intercepted. Same-origin requests pass through unchanged. Cross-origin requests are POSTed to `/api/proxy`, which performs the outbound call from the server with headers that mimic Obsidian's desktop runtime: `Origin: app://obsidian.md` and the browser's own User-Agent. The response body is returned base64-encoded so binary content survives the JSON round-trip; the shim decodes it and hands the caller a normal `Response` or `requestUrl` result.
+The shim handles this transparently. `window.fetch` and `window.requestUrl` are intercepted. Same-origin requests pass through unchanged, as do requests to hosts on the user-configured direct-fetch allowlist, which the browser fetches directly subject to its own CORS enforcement. All other cross-origin requests are POSTed to `/api/proxy`, which performs the outbound call from the server with headers that mimic Obsidian's desktop runtime: `Origin: app://obsidian.md` and the browser's own User-Agent. The response body is returned base64-encoded so binary content survives the JSON round-trip; the shim decodes it and hands the caller a normal `Response` or `requestUrl` result.
 
 The proxy itself is intentionally generic. It forwards method, headers, and body verbatim and returns whatever the upstream sent. It always rejects requests whose hostname resolves to a private, loopback, or link-local address (SSRF guard). Outbound access is governed by `proxyMode`: `any` (the default) reaches any public host, `allowlist` restricts to a configured host list, and `disabled` blocks all proxying; demo mode pins it to `allowlist`. Under the default `any`, the proxy is an open relay to public hosts, which is one of the reasons the server needs to be behind authentication when exposed to the internet.
 
@@ -141,12 +141,12 @@ An Express server that handles filesystem operations, vault management, static f
 - `/api/bootstrap` - one-shot cold-start endpoint; returns vault info + list + metadata tree + plugin list as a single pre-compressed response, cached per vault with mtime-based invalidation.
 - `/api/proxy` - cross-origin HTTP proxy used by the fetch and requestUrl shims.
 - `/api/version` - Ignis version (SemVer), per-build identifier, and pinned Obsidian version.
-- `/api/settings/*` - read and update runtime server settings (cache sizes, request body limit, write-coalesce window, proxy mode and allowlist).
+- `/api/settings/*` - read and update runtime server settings (cache sizes, request body limit, write-coalesce window, proxy mode and allowlist, direct-fetch host allowlist).
 - `/api/plugins/*` - Ignis plugin management (list, enable, disable). __WIP__
 - `/api/ext/:pluginId/*` - routes registered by individual Ignis plugins.
 - `/vault-files/<vaultId>/<path>` - static file serving rooted at a vault, used by Obsidian for image/attachment resource URLs.
 
-**WebSocket:** A file watcher monitors vault directories and pushes change events to connected clients, keeping the client-side metadata and content caches in sync. An echo guard suppresses events caused by the same client's recent writes so they don't bounce back. The watcher also carries plugin-defined message types (e.g. headless-sync status broadcasts).
+**WebSocket:** A file watcher monitors vault directories and pushes change events to connected clients, keeping the client-side metadata and content caches in sync. An echo guard suppresses events caused by the same client's recent writes so they don't bounce back. A ping/pong heartbeat keeps connections alive through idle-timeout proxies and terminates any that stop responding; after a reconnect the client reconciles its metadata cache so file events missed while the socket was down are recovered. The watcher also carries plugin-defined message types (e.g. headless-sync status broadcasts).
 
 **Legacy bridge cleanup:** Earlier versions installed the bridge into each vault's `.obsidian/plugins/`. The bridge is now bundled into the shim and loaded client-side, so on startup the server removes any leftover on-disk `ignis-bridge` install from each vault (and strips it from `community-plugins.json`).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ignis-monorepo",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ignis-monorepo",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "workspaces": [
         "packages/*",
         "apps/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ignis-monorepo",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ignis-monorepo",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -25,6 +25,7 @@
         "esbuild": "^0.20.0",
         "esbuild-svelte": "^0.9.4",
         "lucide-svelte": "^0.577.0",
+        "oxlint": "^1.70.0",
         "path-browserify": "^1.0.1",
         "svelte": "^4.2.20",
         "vitest": "^3.2.4"
@@ -580,6 +581,353 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.70.0.tgz",
+      "integrity": "sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.70.0.tgz",
+      "integrity": "sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.70.0.tgz",
+      "integrity": "sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.70.0.tgz",
+      "integrity": "sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.70.0.tgz",
+      "integrity": "sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.70.0.tgz",
+      "integrity": "sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.70.0.tgz",
+      "integrity": "sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.70.0.tgz",
+      "integrity": "sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.70.0.tgz",
+      "integrity": "sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.70.0.tgz",
+      "integrity": "sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.70.0.tgz",
+      "integrity": "sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.70.0.tgz",
+      "integrity": "sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.70.0.tgz",
+      "integrity": "sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.70.0.tgz",
+      "integrity": "sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.70.0.tgz",
+      "integrity": "sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.70.0.tgz",
+      "integrity": "sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.70.0.tgz",
+      "integrity": "sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.70.0.tgz",
+      "integrity": "sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.70.0.tgz",
+      "integrity": "sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2711,6 +3059,55 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.70.0.tgz",
+      "integrity": "sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.70.0",
+        "@oxlint/binding-android-arm64": "1.70.0",
+        "@oxlint/binding-darwin-arm64": "1.70.0",
+        "@oxlint/binding-darwin-x64": "1.70.0",
+        "@oxlint/binding-freebsd-x64": "1.70.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.70.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.70.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.70.0",
+        "@oxlint/binding-linux-arm64-musl": "1.70.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.70.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.70.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.70.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.70.0",
+        "@oxlint/binding-linux-x64-gnu": "1.70.0",
+        "@oxlint/binding-linux-x64-musl": "1.70.0",
+        "@oxlint/binding-openharmony-arm64": "1.70.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.70.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.70.0",
+        "@oxlint/binding-win32-x64-msvc": "1.70.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.22.1",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
       }
     },
     "node_modules/package-json-from-dist": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignis-monorepo",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "private": true,
   "description": "Monorepo for Ignis: a browser-based Obsidian client. Self-hosted server in apps/ignis-server; shim, UI, and shared libraries in packages/.",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:server": "node apps/ignis-server/server/index.js",
     "dev": "npm run build && npm run dev:server",
     "docker:build": "node apps/ignis-server/scripts/build-image.js",
+    "lint": "oxlint packages apps/ignis-server/server --max-warnings 0 && node scripts/check-error-leaks.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -29,6 +30,7 @@
     "esbuild": "^0.20.0",
     "esbuild-svelte": "^0.9.4",
     "lucide-svelte": "^0.577.0",
+    "oxlint": "^1.70.0",
     "path-browserify": "^1.0.1",
     "svelte": "^4.2.20",
     "vitest": "^3.2.4"

--- a/packages/bridge/src/file-actions.js
+++ b/packages/bridge/src/file-actions.js
@@ -1,4 +1,4 @@
-import { Notice, TFile, TFolder } from "obsidian";
+import { Notice } from "obsidian";
 
 function getVaultId() {
   return window.__currentVaultId || "";

--- a/packages/bridge/src/settings/general-tab.js
+++ b/packages/bridge/src/settings/general-tab.js
@@ -38,7 +38,7 @@ function display(containerEl, app) {
 
   const header = containerEl.createDiv("ignis-header");
 
-  const logo = header.createEl("img", {
+  header.createEl("img", {
     cls: "ignis-header-logo",
     attr: { src: "/assets/ignis.webp", alt: "Ignis" },
   });
@@ -70,7 +70,7 @@ function display(containerEl, app) {
     attr: { target: "_blank", "aria-label": "GitHub" },
   });
 
-  const githubIcon = githubLink.createEl("img", {
+  githubLink.createEl("img", {
     cls: "ignis-github-icon",
     attr: { src: "/assets/github.svg", alt: "GitHub" },
   });

--- a/packages/bridge/src/settings/general-tab.js
+++ b/packages/bridge/src/settings/general-tab.js
@@ -217,6 +217,18 @@ function renderServerSettings(containerEl, current, app) {
 
   proxyAccessField(security, current, app);
 
+  listField(security, {
+    name: "Direct-fetch hosts",
+    desc: "Hosts the browser fetches directly, bypassing the proxy. Only for hosts that allow cross-origin browser requests (CORS);  everything else goes through the proxy. Applies after reload.",
+    value: current.directFetchHosts,
+    key: "directFetchHosts",
+    app,
+    modal: {
+      placeholder: "api.example.com",
+      emptyNote: "No hosts yet.",
+    },
+  });
+
   const advanced = createSettingGroup(containerEl, "Advanced");
 
   numberField(advanced, {

--- a/packages/server-core/src/errors.js
+++ b/packages/server-core/src/errors.js
@@ -1,0 +1,9 @@
+// The safe shape for an unexpected server error returned to the client.
+// Exposes the error code (a coarse identifier such as a Node errno) but never the message, which can carry absolute paths or subprocess output.
+
+function sanitizeError(e) {
+  const code = e == null ? undefined : e.code;
+  return { error: code || "internal", code };
+}
+
+module.exports = { sanitizeError };

--- a/packages/server-core/src/errors.test.mjs
+++ b/packages/server-core/src/errors.test.mjs
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { sanitizeError } = require("./errors.js");
+
+describe("sanitizeError", () => {
+  it("exposes the error code but never the message", () => {
+    const e = Object.assign(new Error("/abs/path/secret leaked here"), {
+      code: "ENOENT",
+    });
+
+    expect(sanitizeError(e)).toEqual({ error: "ENOENT", code: "ENOENT" });
+  });
+
+  it("falls back to 'internal' with no code when the error has none", () => {
+    const result = sanitizeError(new Error("boom with internal detail"));
+
+    expect(result.error).toBe("internal");
+    expect(result.code).toBeUndefined();
+  });
+
+  it("tolerates null, undefined, and non-error input", () => {
+    for (const input of [null, undefined, "a string", 42]) {
+      const result = sanitizeError(input);
+      expect(result.error).toBe("internal");
+      expect(result.code).toBeUndefined();
+    }
+  });
+});

--- a/packages/server-core/src/index.js
+++ b/packages/server-core/src/index.js
@@ -5,6 +5,7 @@ const {
   encodeContentDispositionFilename,
   resolveVaultPath,
 } = require("./path-utils");
+const { sanitizeError } = require("./errors");
 
 module.exports = {
   writeCoalescer,
@@ -12,4 +13,5 @@ module.exports = {
   setupWebSocket,
   encodeContentDispositionFilename,
   resolveVaultPath,
+  sanitizeError,
 };

--- a/packages/server-core/src/path-utils.js
+++ b/packages/server-core/src/path-utils.js
@@ -6,6 +6,8 @@ const path = require("path");
  * Uses RFC 5987 encoding for filename* parameter when needed.
  */
 function encodeContentDispositionFilename(filename) {
+  // The \x00-\x7F range bounds the ASCII set; matching its control-character low end is intentional.
+  // eslint-disable-next-line no-control-regex
   const hasNonASCII = /[^\x00-\x7F]/.test(filename);
 
   // Escape quotes and backslashes in ASCII filename
@@ -16,6 +18,7 @@ function encodeContentDispositionFilename(filename) {
   });
 
   // Remove any control characters that could cause header injection
+  // eslint-disable-next-line no-control-regex
   const sanitizedFilename = escapedFilename.replace(/[\x00-\x1F\x7F]/g, "");
 
   if (!hasNonASCII) {
@@ -34,6 +37,8 @@ function encodeContentDispositionFilename(filename) {
   // Provide both filename (ASCII fallback) and filename* (UTF-8 encoded)
   // For fallback, replace non-ASCII with underscores
   const asciiFallback = filename
+    // Control-character code points are intentional here; this regex bounds the ASCII set.
+    // eslint-disable-next-line no-control-regex
     .replace(/[^\x00-\x7F]/g, "_")
     .replace(/["\\]/g, function (match) {
       if (match === '"') return '\\"';

--- a/packages/server-core/src/path-utils.js
+++ b/packages/server-core/src/path-utils.js
@@ -9,7 +9,7 @@ function encodeContentDispositionFilename(filename) {
   const hasNonASCII = /[^\x00-\x7F]/.test(filename);
 
   // Escape quotes and backslashes in ASCII filename
-  const escapedFilename = filename.replace(/["\\ ]/g, function (match) {
+  const escapedFilename = filename.replace(/["\\]/g, function (match) {
     if (match === '"') return '\\"';
     if (match === "\\") return "\\\\";
     return match;
@@ -35,7 +35,7 @@ function encodeContentDispositionFilename(filename) {
   // For fallback, replace non-ASCII with underscores
   const asciiFallback = filename
     .replace(/[^\x00-\x7F]/g, "_")
-    .replace(/["\\ ]/g, function (match) {
+    .replace(/["\\]/g, function (match) {
       if (match === '"') return '\\"';
       if (match === "\\") return "\\\\";
       return match;

--- a/packages/server-core/src/watcher.js
+++ b/packages/server-core/src/watcher.js
@@ -19,7 +19,7 @@ function startWatching(vaultId, vaultPath) {
       pollInterval: 100,
     },
     ignored: [
-      /(^|[\/\\])\.git([\/\\]|$)/, // .git directories
+      /(^|[/\\])\.git([/\\]|$)/, // .git directories
     ],
   });
 

--- a/packages/server-core/src/write-coalescer.js
+++ b/packages/server-core/src/write-coalescer.js
@@ -31,9 +31,19 @@ async function writeToDisk(absPath, data, encoding) {
   );
 
   lastWriteTime.set(absPath, Date.now());
-  const stat = await fs.promises.stat(absPath);
 
-  return { mtime: stat.mtimeMs, size: stat.size };
+  // A concurrent delete can remove the file between the write and the stat (a rapid write-then-delete on the same path).
+  // The write itself succeeds, so report synthetic metadata rather than failing the request on the now-missing file.
+  try {
+    const stat = await fs.promises.stat(absPath);
+    return { mtime: stat.mtimeMs, size: stat.size };
+  } catch (e) {
+    if (e.code === "ENOENT") {
+      return { mtime: Date.now(), size: estimateSize(data, encoding) };
+    }
+
+    throw e;
+  }
 }
 
 function flushEntry(absPath) {

--- a/packages/server-core/src/write-coalescer.test.mjs
+++ b/packages/server-core/src/write-coalescer.test.mjs
@@ -99,6 +99,18 @@ describe("writeCoalesced", () => {
 
     expect(elapsed).toBeLessThan(20);
   });
+
+  it("returns synthetic metadata when the file is deleted before the post-write stat", async () => {
+    const filePath = path.join(tmpDir, "race.txt");
+    vi.spyOn(fs.promises, "stat").mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+
+    const result = await coalescer.writeCoalesced(filePath, "hello", "utf-8");
+
+    expect(result.size).toBe(5);
+    expect(result.mtime).toBeGreaterThan(0);
+  });
 });
 
 describe("getPending", () => {

--- a/packages/server-core/src/ws.js
+++ b/packages/server-core/src/ws.js
@@ -9,8 +9,8 @@ function toOriginSet(list) {
 
 const HEARTBEAT_INTERVAL_MS = 30000;
 
-// Terminates sockets that have not ponged since the previous sweep, and pings the rest.
-// A socket silently dropped by an idle-timeout proxy fails the next isAlive check and is terminated.
+// Pings each live client every sweep so the connection stays warm through idle-timeout proxies.
+// A client that did not pong since the previous sweep is treated as dead and terminated.
 function heartbeatSweep(clients) {
   for (const ws of clients) {
     if (ws.isAlive === false) {
@@ -231,7 +231,7 @@ function setupWebSocket(server, opts = {}) {
     });
   });
 
-  // Terminate dead connections behind proxies that silently drop idle sockets.
+  // Heartbeat keeps sockets alive through idle-timeout proxies, and terminates any that stop responding.
   const heartbeat = setInterval(
     () => heartbeatSweep(wss.clients),
     HEARTBEAT_INTERVAL_MS,

--- a/packages/server-core/src/ws.js
+++ b/packages/server-core/src/ws.js
@@ -7,6 +7,22 @@ function toOriginSet(list) {
   return Array.isArray(list) && list.length > 0 ? new Set(list) : null;
 }
 
+const HEARTBEAT_INTERVAL_MS = 30000;
+
+// Terminates sockets that have not ponged since the previous sweep, and pings the rest.
+// A socket silently dropped by an idle-timeout proxy fails the next isAlive check and is terminated.
+function heartbeatSweep(clients) {
+  for (const ws of clients) {
+    if (ws.isAlive === false) {
+      ws.terminate();
+      continue;
+    }
+
+    ws.isAlive = false;
+    ws.ping();
+  }
+}
+
 function setupWebSocket(server, opts = {}) {
   const { getVaultPath, originAllowlist } = opts;
 
@@ -126,6 +142,12 @@ function setupWebSocket(server, opts = {}) {
     const vaultPath = getVaultPath(vaultId);
     console.log(`[ws] Client connected to vault: ${vaultId}`);
 
+    // isAlive is reset by each pong; the heartbeat sweep terminates sockets that miss one.
+    ws.isAlive = true;
+    ws.on("pong", () => {
+      ws.isAlive = true;
+    });
+
     if (!clientsByVault.has(vaultId)) {
       clientsByVault.set(vaultId, new Set());
     }
@@ -209,7 +231,16 @@ function setupWebSocket(server, opts = {}) {
     });
   });
 
+  // Terminate dead connections behind proxies that silently drop idle sockets.
+  const heartbeat = setInterval(
+    () => heartbeatSweep(wss.clients),
+    HEARTBEAT_INTERVAL_MS,
+  );
+  heartbeat.unref?.();
+
+  wss.on("close", () => clearInterval(heartbeat));
+
   return wss;
 }
 
-module.exports = { setupWebSocket };
+module.exports = { setupWebSocket, heartbeatSweep };

--- a/packages/server-core/src/ws.test.mjs
+++ b/packages/server-core/src/ws.test.mjs
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { heartbeatSweep } = require("./ws.js");
+
+function fakeSocket(isAlive) {
+  return { isAlive, ping: vi.fn(), terminate: vi.fn() };
+}
+
+describe("ws heartbeat sweep", () => {
+  it("terminates a socket that has not ponged since the last sweep", () => {
+    const dead = fakeSocket(false);
+
+    heartbeatSweep([dead]);
+
+    expect(dead.terminate).toHaveBeenCalledTimes(1);
+    expect(dead.ping).not.toHaveBeenCalled();
+  });
+
+  it("pings a live socket and marks it pending until its next pong", () => {
+    const alive = fakeSocket(true);
+
+    heartbeatSweep([alive]);
+
+    expect(alive.ping).toHaveBeenCalledTimes(1);
+    expect(alive.terminate).not.toHaveBeenCalled();
+    expect(alive.isAlive).toBe(false);
+  });
+
+  it("terminates the dead and pings the live in the same sweep", () => {
+    const dead = fakeSocket(false);
+    const alive = fakeSocket(true);
+
+    heartbeatSweep(new Set([dead, alive]));
+
+    expect(dead.terminate).toHaveBeenCalledTimes(1);
+    expect(dead.ping).not.toHaveBeenCalled();
+    expect(alive.ping).toHaveBeenCalledTimes(1);
+    expect(alive.terminate).not.toHaveBeenCalled();
+    expect(alive.isAlive).toBe(false);
+  });
+});

--- a/packages/shim/src/electron/remote/dialog.js
+++ b/packages/shim/src/electron/remote/dialog.js
@@ -206,7 +206,7 @@ export const dialogShim = {
     }
 
     const defaultName =
-      options?.defaultPath?.split(/[\/\\]/).pop() || "download";
+      options?.defaultPath?.split(/[/\\]/).pop() || "download";
     const name = await showPromptDialog(
       "Save File",
       "Save as:",

--- a/packages/shim/src/electron/remote/window.js
+++ b/packages/shim/src/electron/remote/window.js
@@ -148,6 +148,8 @@ const currentWebContents = {
 
   executeJavaScript(code) {
     try {
+      // executeJavaScript runs a code string in the page context; eval performs that execution.
+      // eslint-disable-next-line no-eval
       return Promise.resolve(eval(code));
     } catch (e) {
       return Promise.reject(e);
@@ -208,7 +210,6 @@ const currentWebContents = {
       .read()
       .then(async (items) => {
         const dt = new DataTransfer();
-        let hasFiles = false;
 
         for (const item of items) {
           for (const type of item.types) {
@@ -222,7 +223,6 @@ const currentWebContents = {
               dt.items.add(
                 new File([blob], `pasted-image.${ext}`, { type }),
               );
-              hasFiles = true;
             }
           }
         }
@@ -309,6 +309,8 @@ export function registerPopupWindow() {
     },
     executeJavaScript(code) {
       try {
+        // executeJavaScript runs a code string in the page context; eval performs that execution.
+        // eslint-disable-next-line no-eval
         return Promise.resolve(eval(code));
       } catch (e) {
         return Promise.reject(e);

--- a/packages/shim/src/fs/index.js
+++ b/packages/shim/src/fs/index.js
@@ -18,7 +18,13 @@ const contentCache = new ContentCache();
 const fsPromises = createFsPromises(metadataCache, contentCache, transport);
 const fsSync = createFsSync(metadataCache, contentCache, transport);
 const fsWatch = createFsWatch(transport);
-const watcherClient = createWatcherClient(metadataCache, contentCache, fsWatch, wsClient);
+const watcherClient = createWatcherClient(
+  metadataCache,
+  contentCache,
+  fsWatch,
+  wsClient,
+  transport,
+);
 const fdOps = createFdOps(metadataCache, contentCache, transport);
 const fsCallbacks = createFsCallbacks(fsPromises);
 

--- a/packages/shim/src/fs/indexer-prefetch.js
+++ b/packages/shim/src/fs/indexer-prefetch.js
@@ -1,10 +1,7 @@
-// Eager batch pre-fetch of vault content into ContentCache.
-//
-// Fired once after the metadata cache is populated. Iterates the tree in
-// directory-traversal order and pulls text file contents in batches via
-// /api/fs/batch-read. Caps at MAX_BYTES so it doesn't thrash the LRU.
-// Drops content directly into ContentCache; the indexer hits the cache
-// instead of fetching each file individually.
+// Batch pre-fetch of vault content into ContentCache.
+// Pulls text file contents in batches via /api/fs/batch-read and drops them into ContentCache so Obsidian's startup reads hit the cache instead of fetching each file individually.
+// The priority slice (.obsidian configs and plugin entry files) is fetched first and its promise resolves once it lands, so boot can wait for those reads to be warm.
+// The bulk slice (everything else) streams afterward without blocking boot.
 
 const TEXT_EXTENSIONS = new Set([
   ".md", ".markdown", ".txt", ".json", ".csv",
@@ -13,8 +10,12 @@ const TEXT_EXTENSIONS = new Set([
   ".svg",
 ]);
 
-const MAX_BYTES = 30 * 1024 * 1024; // 30 MB
-const MAX_FILE_BYTES = 512 * 1024; // skip files larger than 512 KB
+const MAX_BYTES = 30 * 1024 * 1024; // 30 MB total across both slices
+const MAX_FILE_BYTES = 512 * 1024; // skip bulk files larger than 512 KB
+// Plugin main.js bundles can run a few MB and Obsidian needs them at boot, so the priority slice accepts larger files than the bulk slice.
+const PRIORITY_MAX_FILE_BYTES = 4 * 1024 * 1024; // 4 MB
+// Cap the priority slice's share of the total so a heavy config or plugin set cannot starve the bulk slice.
+const PRIORITY_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
 const BATCH_SIZE = 50;
 
 function isTextPath(path) {
@@ -27,36 +28,68 @@ function isTextPath(path) {
   return TEXT_EXTENSIONS.has(path.slice(dot).toLowerCase());
 }
 
-function selectPrefetchTargets(tree) {
-  const paths = [];
+// Boot-critical files: root-level .obsidian configs and each plugin's entry files.
+// Plugin data.json and other nested config fall to the bulk slice so a large blob does not inflate the awaited slice.
+function isPriorityPath(path) {
+  if (!path.startsWith(".obsidian/")) {
+    return false;
+  }
+
+  // Root-level configs only (app.json, appearance.json, core-plugins.json, workspace.json, etc.).
+  if (/^\.obsidian\/[^/]+\.json$/.test(path)) {
+    return true;
+  }
+
+  return /^\.obsidian\/plugins\/[^/]+\/(main\.js|manifest\.json|styles\.css)$/.test(
+    path,
+  );
+}
+
+function collectSlice(entries, predicate, perFileCap, budget) {
+  const files = [];
   let bytes = 0;
 
-  // Iterate in tree key order, which already matches directory traversal
-  // because the server's walk emits parent-before-children.
-  for (const [path, entry] of Object.entries(tree)) {
-    if (entry.type !== "file") {
-      continue;
-    }
-
-    if (!isTextPath(path)) {
+  for (const [path, entry] of entries) {
+    if (entry.type !== "file" || !isTextPath(path) || !predicate(path)) {
       continue;
     }
 
     const size = entry.size || 0;
 
-    if (size === 0 || size > MAX_FILE_BYTES) {
+    if (size === 0 || size > perFileCap) {
       continue;
     }
 
-    if (bytes + size > MAX_BYTES) {
-      break;
+    if (bytes + size > budget) {
+      continue;
     }
 
-    paths.push(path);
+    files.push({ path, size });
     bytes += size;
   }
 
-  return { paths, bytes };
+  return { files, bytes };
+}
+
+function selectPrefetchTargets(tree) {
+  // Tree key order matches directory traversal (the server walk emits parent before children).
+  const entries = Object.entries(tree);
+  const priority = collectSlice(
+    entries,
+    isPriorityPath,
+    PRIORITY_MAX_FILE_BYTES,
+    PRIORITY_MAX_BYTES,
+  );
+
+  // Bulk fills whatever byte budget the priority slice left.
+  const bulk = collectSlice(
+    entries,
+    (path) => !isPriorityPath(path),
+    MAX_FILE_BYTES,
+    MAX_BYTES - priority.bytes,
+  );
+
+  return { priority, bulk };
 }
 
 async function fetchBatch(vaultId, paths) {
@@ -73,41 +106,84 @@ async function fetchBatch(vaultId, paths) {
   return res.json();
 }
 
-export async function prefetchVaultContent(vaultId, tree, contentCache) {
-  if (!vaultId || !tree) {
-    return;
-  }
-
-  const { paths, bytes } = selectPrefetchTargets(tree);
-
-  if (paths.length === 0) {
+async function runBatches(vaultId, slice, contentCache, label, onProgress) {
+  if (slice.files.length === 0) {
     return;
   }
 
   const t0 = Date.now();
   let cached = 0;
+  let received = 0;
 
-  for (let i = 0; i < paths.length; i += BATCH_SIZE) {
-    const batch = paths.slice(i, i + BATCH_SIZE);
+  // Report the total up front so the splash shows the target before the first batch lands.
+  if (onProgress) {
+    onProgress(0, slice.bytes);
+  }
+
+  for (let i = 0; i < slice.files.length; i += BATCH_SIZE) {
+    const batch = slice.files.slice(i, i + BATCH_SIZE);
+
+    let result;
 
     try {
-      const result = await fetchBatch(vaultId, batch);
-
-      for (const [path, content] of Object.entries(result.files || {})) {
-        if (typeof content === "string") {
-          contentCache.set(path, content);
-          cached++;
-        }
-      }
+      result = await fetchBatch(
+        vaultId,
+        batch.map((f) => f.path),
+      );
     } catch (e) {
-      console.warn("[ignis] Prefetch batch failed:", e.message);
+      // Abandon the rest of this slice; the returned promise still resolves so boot is never blocked on a failed batch.
+      console.warn(`[ignis] Prefetch ${label} batch failed:`, e.message);
       return;
+    }
+
+    for (const [path, content] of Object.entries(result.files || {})) {
+      if (typeof content === "string") {
+        contentCache.set(path, content);
+        cached++;
+      }
+    }
+
+    if (onProgress) {
+      for (const f of batch) {
+        received += f.size;
+      }
+
+      onProgress(received, slice.bytes);
     }
   }
 
   const ms = Date.now() - t0;
 
   console.log(
-    `[ignis] Prefetched ${cached}/${paths.length} files (${(bytes / 1024).toFixed(0)} KB) in ${ms}ms`,
+    `[ignis] Prefetched ${label} ${cached}/${slice.files.length} files (${(slice.bytes / 1024).toFixed(0)} KB) in ${ms}ms`,
   );
+}
+
+// Returns { priority, bulk }: a promise for each slice.
+// The priority promise resolves once the boot-critical files have landed (or were abandoned on a batch failure), so it is always safe to await.
+export function prefetchVaultContent(vaultId, tree, contentCache, options = {}) {
+  if (!vaultId || !tree) {
+    return { priority: Promise.resolve(), bulk: Promise.resolve() };
+  }
+
+  const { priority, bulk } = selectPrefetchTargets(tree);
+
+  const priorityDone = runBatches(
+    vaultId,
+    priority,
+    contentCache,
+    "priority",
+    options.onProgress,
+  );
+
+  // Bulk streams after the priority slice so it does not contend for the connection pool while boot is waiting on priority.
+  // It runs regardless of how priority settled and swallows its own rejection, since init.js discards this promise.
+  const bulkDone = priorityDone
+    .catch(() => {})
+    .then(() => runBatches(vaultId, bulk, contentCache, "bulk"))
+    .catch((e) => {
+      console.warn("[ignis] Prefetch bulk failed:", e && e.message);
+    });
+
+  return { priority: priorityDone, bulk: bulkDone };
 }

--- a/packages/shim/src/fs/indexer-prefetch.test.js
+++ b/packages/shim/src/fs/indexer-prefetch.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { prefetchVaultContent } from "./indexer-prefetch.js";
+
+const MB = 1024 * 1024;
+
+// Every selection rule.
+const tree = {
+  ".obsidian/app.json": { type: "file", size: 100 },
+  ".obsidian/community-plugins.json": { type: "file", size: 50 },
+  ".obsidian/plugins/big/main.js": { type: "file", size: 2 * MB },
+  ".obsidian/plugins/big/manifest.json": { type: "file", size: 80 },
+  ".obsidian/plugins/big/styles.css": { type: "file", size: 200 },
+  ".obsidian/plugins/big/data.json": { type: "file", size: 300 * 1024 },
+  "Note.md": { type: "file", size: 100 },
+  "Big.md": { type: "file", size: 600 * 1024 },
+  "plugins/fake/main.js": { type: "file", size: 100 },
+  somedir: { type: "directory" },
+};
+
+const PRIORITY_BYTES = 100 + 50 + 2 * MB + 80 + 200;
+
+let fetchCalls;
+
+function makeCache() {
+  const store = new Map();
+  return { store, set: (path, content) => store.set(path, content) };
+}
+
+beforeEach(() => {
+  fetchCalls = [];
+  globalThis.fetch = vi.fn(async (url, init) => {
+    const paths = JSON.parse(init.body).paths;
+    fetchCalls.push(paths);
+
+    const files = {};
+
+    for (const p of paths) {
+      files[p] = "content:" + p;
+    }
+
+    return { ok: true, json: async () => ({ files }) };
+  });
+});
+
+afterEach(() => {
+  delete globalThis.fetch;
+  vi.restoreAllMocks();
+});
+
+describe("prefetchVaultContent slicing", () => {
+  it("fetches the priority slice before the bulk slice", async () => {
+    const result = prefetchVaultContent("v", tree, makeCache());
+    await result.bulk;
+
+    expect(fetchCalls.length).toBe(2);
+    const [priorityPaths, bulkPaths] = fetchCalls;
+
+    expect(priorityPaths).toEqual(
+      expect.arrayContaining([
+        ".obsidian/app.json",
+        ".obsidian/community-plugins.json",
+        ".obsidian/plugins/big/main.js",
+        ".obsidian/plugins/big/manifest.json",
+        ".obsidian/plugins/big/styles.css",
+      ]),
+    );
+    expect(priorityPaths).not.toContain("Note.md");
+
+    expect(bulkPaths).toEqual(
+      expect.arrayContaining(["Note.md", "plugins/fake/main.js"]),
+    );
+  });
+
+  it("anchors the plugin predicate to .obsidian, so a bare plugins/ path is bulk", async () => {
+    const result = prefetchVaultContent("v", tree, makeCache());
+    await result.bulk;
+
+    expect(fetchCalls[0]).not.toContain("plugins/fake/main.js");
+    expect(fetchCalls[1]).toContain("plugins/fake/main.js");
+  });
+
+  it("leaves plugin data.json to the bulk slice, not priority", async () => {
+    const result = prefetchVaultContent("v", tree, makeCache());
+    await result.bulk;
+
+    expect(fetchCalls[0]).not.toContain(".obsidian/plugins/big/data.json");
+    expect(fetchCalls[1]).toContain(".obsidian/plugins/big/data.json");
+  });
+
+  it("caps the priority slice at its own byte budget", async () => {
+    // Three 4MB plugin entry files: two fit the 10MB priority budget, the third is dropped.
+    const bigTree = {
+      ".obsidian/plugins/a/main.js": { type: "file", size: 4 * MB },
+      ".obsidian/plugins/b/main.js": { type: "file", size: 4 * MB },
+      ".obsidian/plugins/c/main.js": { type: "file", size: 4 * MB },
+    };
+
+    const result = prefetchVaultContent("v", bigTree, makeCache());
+    await result.bulk;
+
+    expect(fetchCalls[0].length).toBe(2);
+  });
+
+  it("drops a bulk file over the 512KB per-file cap", async () => {
+    const result = prefetchVaultContent("v", tree, makeCache());
+    await result.bulk;
+
+    expect(fetchCalls.flat()).not.toContain("Big.md");
+  });
+
+  it("reports priority byte progress from zero up to the slice total", async () => {
+    const onProgress = vi.fn();
+    const result = prefetchVaultContent("v", tree, makeCache(), { onProgress });
+    await result.priority;
+
+    expect(onProgress).toHaveBeenCalledWith(0, PRIORITY_BYTES);
+    expect(onProgress).toHaveBeenLastCalledWith(PRIORITY_BYTES, PRIORITY_BYTES);
+  });
+
+  it("caches returned content under its path", async () => {
+    const cache = makeCache();
+    const result = prefetchVaultContent("v", tree, cache);
+    await result.bulk;
+
+    expect(cache.store.get(".obsidian/app.json")).toBe(
+      "content:.obsidian/app.json",
+    );
+    expect(cache.store.get("Note.md")).toBe("content:Note.md");
+  });
+
+  it("resolves both promises without fetching when there is no vault", async () => {
+    const result = prefetchVaultContent("", tree, makeCache());
+
+    await result.priority;
+    await result.bulk;
+
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it("resolves the priority promise even when a batch fails", async () => {
+    globalThis.fetch = vi.fn(async () => ({ ok: false, status: 500 }));
+
+    const result = prefetchVaultContent("v", tree, makeCache());
+
+    await expect(result.priority).resolves.toBeUndefined();
+  });
+});

--- a/packages/shim/src/fs/metadata-cache.js
+++ b/packages/shim/src/fs/metadata-cache.js
@@ -62,7 +62,7 @@ export class MetadataCache {
     const results = [];
     const seen = new Set();
 
-    for (const [key, meta] of this._entries) {
+    for (const key of this._entries.keys()) {
       if (prefix === "" || key.startsWith(prefix)) {
         const rest = key.slice(prefix.length);
         const slashIdx = rest.indexOf("/");

--- a/packages/shim/src/fs/metadata-cache.js
+++ b/packages/shim/src/fs/metadata-cache.js
@@ -93,6 +93,11 @@ export class MetadataCache {
     return this._entries.size;
   }
 
+  // Normalized keys of every entry, for callers that diff the cache against a fresh tree.
+  keys() {
+    return [...this._entries.keys()];
+  }
+
   toStat(path) {
     const meta = this.get(path);
 

--- a/packages/shim/src/fs/promises-mutations.test.js
+++ b/packages/shim/src/fs/promises-mutations.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createFsPromises } from "./promises.js";
+import { registerPathResolver, _reset } from "./transforms.js";
+import { isRecentLocalOp } from "./echo-guard.js";
+
+function makeDeps() {
+  const store = new Map();
+
+  const metadataCache = {
+    has: (p) => store.has(p),
+    get: (p) => (store.has(p) ? store.get(p) : null),
+    set: (p, m) => store.set(p, m),
+    delete: (p) => store.delete(p),
+    toStat: (p) =>
+      store.has(p)
+        ? {
+            type: store.get(p).type,
+            isDirectory: () => store.get(p).type === "directory",
+            isFile: () => store.get(p).type === "file",
+          }
+        : null,
+    readdir: () => [],
+  };
+
+  const contentCache = {
+    get: () => null,
+    set: vi.fn(),
+    delete: vi.fn(),
+    invalidate: vi.fn(),
+  };
+
+  const transport = {
+    mkdir: vi.fn(async () => {}),
+    rmdir: vi.fn(async () => {}),
+    stat: vi.fn(async () => ({ type: "file", size: 1 })),
+    readFile: vi.fn(async () => {
+      throw new Error("transport.readFile should not be called");
+    }),
+  };
+
+  return { metadataCache, contentCache, transport, store };
+}
+
+describe("promises directory mutations honor path resolvers", () => {
+  afterEach(() => _reset());
+
+  it("mkdir uses the resolved path for cache, echo-guard, and transport", async () => {
+    registerPathResolver(
+      (p) => p === "logical/dir",
+      () => "physical/dir",
+    );
+
+    const deps = makeDeps();
+    const fs = createFsPromises(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
+
+    await fs.mkdir("logical/dir", { recursive: true });
+
+    expect(deps.store.get("physical/dir")).toEqual({ type: "directory" });
+    expect(deps.store.has("logical/dir")).toBe(false);
+    expect(deps.transport.mkdir).toHaveBeenCalledWith("physical/dir", true);
+    expect(isRecentLocalOp("physical/dir")).toBe(true);
+    expect(isRecentLocalOp("logical/dir")).toBe(false);
+  });
+
+  it("rmdir uses the resolved path for cache, echo-guard, and transport", async () => {
+    registerPathResolver(
+      (p) => p === "logical/dir",
+      () => "physical/dir",
+    );
+
+    const deps = makeDeps();
+    const fs = createFsPromises(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
+    deps.store.set("physical/dir", { type: "directory" });
+
+    await fs.rmdir("logical/dir");
+
+    expect(deps.store.has("physical/dir")).toBe(false);
+    expect(deps.transport.rmdir).toHaveBeenCalledWith("physical/dir");
+    expect(isRecentLocalOp("physical/dir")).toBe(true);
+  });
+});
+
+describe("promises readFile existence", () => {
+  afterEach(() => _reset());
+
+  it("answers ENOENT from the cache for a missing non-redirected path, no transport", async () => {
+    const deps = makeDeps();
+    const fs = createFsPromises(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
+
+    await expect(
+      fs.readFile("/.obsidian/backlink.json", "utf8"),
+    ).rejects.toThrow(/ENOENT/);
+    expect(deps.transport.readFile).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the original path for a redirected miss", async () => {
+    registerPathResolver(
+      (p) => p === ".obsidian/workspace.json",
+      () => ".obsidian/workspace.Work.json",
+    );
+
+    const deps = makeDeps();
+    deps.transport.readFile = vi.fn(async (p) => {
+      if (p === ".obsidian/workspace.Work.json") {
+        const e = new Error("ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      }
+
+      return "BASE";
+    });
+
+    const fs = createFsPromises(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
+
+    // Returns the base content after the redirect target 404s: the fallback fired.
+    await expect(fs.readFile("/.obsidian/workspace.json", "utf8")).resolves.toBe(
+      "BASE",
+    );
+    expect(deps.transport.readFile).toHaveBeenCalledWith(
+      ".obsidian/workspace.Work.json",
+      "utf8",
+    );
+  });
+});

--- a/packages/shim/src/fs/promises.js
+++ b/packages/shim/src/fs/promises.js
@@ -4,6 +4,7 @@ import {
   applyReadTransform,
   applyWriteTransform,
   resolvePath,
+  resolvePathInfo,
 } from "./transforms.js";
 import { hasVirtualFile, getVirtualFile } from "./virtual-files.js";
 import { realpathSync } from "./realpath.js";
@@ -53,7 +54,7 @@ export function createFsPromises(metadataCache, contentCache, transport) {
       }
 
       const wantText = encoding === "utf8" || encoding === "utf-8";
-      const resolved = resolvePath(path);
+      const { resolved, redirected } = resolvePathInfo(path);
 
       // Virtual plugin source overrides any cache/transport version.
       if (hasVirtualFile(resolved)) {
@@ -86,8 +87,9 @@ export function createFsPromises(metadataCache, contentCache, transport) {
           throw e;
         }
 
-        if (!meta && resolved && resolved === path) {
-          // Throw ENOENT only when not redirected; redirected paths fall through to the transport's fallback.
+        if (!meta && !redirected) {
+          // The metadata cache holds every existing path (populated at bootstrap, kept current by the watcher).
+          // A cache miss on a non-redirected path is genuinely absent. Redirected paths fall through to the transport.
           const e = new Error(
             `ENOENT: no such file or directory, open '${path}'`,
           );
@@ -102,7 +104,7 @@ export function createFsPromises(metadataCache, contentCache, transport) {
         try {
           result = await transport.readFile(resolved, encoding);
         } catch (e) {
-          if (resolved !== path && e.code === "ENOENT") {
+          if (redirected && e.code === "ENOENT") {
             result = await transport.readFile(path, encoding);
           } else {
             throw e;
@@ -207,16 +209,20 @@ export function createFsPromises(metadataCache, contentCache, transport) {
       const recursive =
         typeof options === "object" ? !!options.recursive : !!options;
 
-      markLocalOp(path);
-      metadataCache.set(path, { type: "directory" });
+      const resolved = resolvePath(path);
 
-      await transport.mkdir(path, recursive);
+      markLocalOp(resolved);
+      metadataCache.set(resolved, { type: "directory" });
+
+      await transport.mkdir(resolved, recursive);
     },
 
     async rmdir(path) {
-      markLocalOp(path);
-      metadataCache.delete(path);
-      await transport.rmdir(path);
+      const resolved = resolvePath(path);
+
+      markLocalOp(resolved);
+      metadataCache.delete(resolved);
+      await transport.rmdir(resolved);
     },
 
     async rm(path, options) {

--- a/packages/shim/src/fs/sync-mutations.test.js
+++ b/packages/shim/src/fs/sync-mutations.test.js
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { createFsSync } from "./sync.js";
-import { resolvePath } from "./transforms.js";
+import { resolvePath, registerPathResolver, _reset } from "./transforms.js";
+import { isRecentLocalOp } from "./echo-guard.js";
 
 function makeDeps() {
   const store = new Map();
@@ -43,6 +44,9 @@ function makeDeps() {
     appendFile: vi.fn(async () => {}),
     utimes: vi.fn(async () => {}),
     stat: vi.fn(async () => ({ type: "file", size: 1 })),
+    readFileSync: vi.fn(() => {
+      throw new Error("transport.readFileSync should not be called");
+    }),
   };
 
   return { metadataCache, contentCache, transport, store };
@@ -51,7 +55,11 @@ function makeDeps() {
 describe("sync fs mutations", () => {
   it("lstatSync mirrors statSync", () => {
     const deps = makeDeps();
-    const fs = createFsSync(deps.metadataCache, deps.contentCache, deps.transport);
+    const fs = createFsSync(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
     deps.store.set(resolvePath("dir"), { type: "directory" });
 
     expect(fs.lstatSync("dir").isDirectory()).toBe(true);
@@ -59,7 +67,11 @@ describe("sync fs mutations", () => {
 
   it("mkdirSync updates the cache and fires the transport", () => {
     const deps = makeDeps();
-    const fs = createFsSync(deps.metadataCache, deps.contentCache, deps.transport);
+    const fs = createFsSync(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
 
     fs.mkdirSync("newdir", { recursive: true });
 
@@ -69,7 +81,11 @@ describe("sync fs mutations", () => {
 
   it("rmSync deletes from the cache and fires the transport", () => {
     const deps = makeDeps();
-    const fs = createFsSync(deps.metadataCache, deps.contentCache, deps.transport);
+    const fs = createFsSync(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
     const key = resolvePath("gone.md");
     deps.store.set(key, { type: "file" });
 
@@ -81,7 +97,11 @@ describe("sync fs mutations", () => {
 
   it("renameSync moves cache metadata and fires the transport", () => {
     const deps = makeDeps();
-    const fs = createFsSync(deps.metadataCache, deps.contentCache, deps.transport);
+    const fs = createFsSync(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
     const from = resolvePath("a.md");
     const to = resolvePath("b.md");
     deps.store.set(from, { type: "file", size: 2 });
@@ -95,7 +115,11 @@ describe("sync fs mutations", () => {
 
   it("copyFileSync optimistically mirrors source metadata and fires the transport", () => {
     const deps = makeDeps();
-    const fs = createFsSync(deps.metadataCache, deps.contentCache, deps.transport);
+    const fs = createFsSync(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
     const srcKey = resolvePath("src.md");
     const destKey = resolvePath("dest.md");
     deps.store.set(srcKey, { type: "file", size: 9 });
@@ -108,7 +132,11 @@ describe("sync fs mutations", () => {
 
   it("utimesSync sets mtime and fires the transport", () => {
     const deps = makeDeps();
-    const fs = createFsSync(deps.metadataCache, deps.contentCache, deps.transport);
+    const fs = createFsSync(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
     const key = resolvePath("note.md");
     deps.store.set(key, { type: "file", mtime: 0 });
 
@@ -117,12 +145,101 @@ describe("sync fs mutations", () => {
     expect(deps.store.get(key).mtime).toBe(222);
     expect(deps.transport.utimes).toHaveBeenCalled();
   });
+});
 
-  it("chmodSync is a no-op that does not throw", () => {
+describe("directory mutations honor path resolvers", () => {
+  afterEach(() => _reset());
+
+  it("mkdirSync uses the resolved path for cache, echo-guard, and transport", () => {
+    registerPathResolver(
+      (p) => p === "logical/dir",
+      () => "physical/dir",
+    );
+
     const deps = makeDeps();
-    const fs = createFsSync(deps.metadataCache, deps.contentCache, deps.transport);
+    const fs = createFsSync(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
 
-    expect(() => fs.chmodSync("note.md", 0o644)).not.toThrow();
-    expect(fs.chmodSync("note.md", 0o644)).toBeUndefined();
+    fs.mkdirSync("logical/dir", { recursive: true });
+
+    expect(deps.store.get("physical/dir")).toEqual({ type: "directory" });
+    expect(deps.store.has("logical/dir")).toBe(false);
+    expect(deps.transport.mkdir).toHaveBeenCalledWith("physical/dir", true);
+    expect(isRecentLocalOp("physical/dir")).toBe(true);
+    expect(isRecentLocalOp("logical/dir")).toBe(false);
+  });
+
+  it("rmdirSync uses the resolved path for cache, echo-guard, and transport", () => {
+    registerPathResolver(
+      (p) => p === "logical/dir",
+      () => "physical/dir",
+    );
+
+    const deps = makeDeps();
+    const fs = createFsSync(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
+    deps.store.set("physical/dir", { type: "directory" });
+
+    fs.rmdirSync("logical/dir");
+
+    expect(deps.store.has("physical/dir")).toBe(false);
+    expect(deps.transport.rmdir).toHaveBeenCalledWith("physical/dir");
+    expect(isRecentLocalOp("physical/dir")).toBe(true);
+  });
+});
+
+describe("readFileSync existence", () => {
+  afterEach(() => _reset());
+
+  it("answers ENOENT from the cache for a missing non-redirected path, no transport", () => {
+    const deps = makeDeps();
+    const fs = createFsSync(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
+
+    // Leading slash: normalize strips it, so resolved !== the raw argument.
+    expect(() => fs.readFileSync("/.obsidian/backlink.json", "utf8")).toThrow(
+      /ENOENT/,
+    );
+    expect(deps.transport.readFileSync).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the original path for a redirected miss", () => {
+    registerPathResolver(
+      (p) => p === ".obsidian/workspace.json",
+      () => ".obsidian/workspace.Work.json",
+    );
+
+    const deps = makeDeps();
+    deps.transport.readFileSync = vi.fn((p) => {
+      if (p === ".obsidian/workspace.Work.json") {
+        const e = new Error("ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      }
+
+      return "BASE";
+    });
+
+    const fs = createFsSync(
+      deps.metadataCache,
+      deps.contentCache,
+      deps.transport,
+    );
+
+    // Returns the base content after the redirect target 404s: the fallback fired.
+    expect(fs.readFileSync("/.obsidian/workspace.json", "utf8")).toBe("BASE");
+    expect(deps.transport.readFileSync).toHaveBeenCalledWith(
+      ".obsidian/workspace.Work.json",
+      "utf8",
+    );
   });
 });

--- a/packages/shim/src/fs/sync.js
+++ b/packages/shim/src/fs/sync.js
@@ -4,6 +4,7 @@ import {
   applyReadTransform,
   applyWriteTransform,
   resolvePath,
+  resolvePathInfo,
 } from "./transforms.js";
 import { hasVirtualFile, getVirtualFile } from "./virtual-files.js";
 
@@ -69,7 +70,7 @@ export function createFsSync(metadataCache, contentCache, transport) {
       }
 
       const wantText = encoding === "utf8" || encoding === "utf-8";
-      const resolved = resolvePath(path);
+      const { resolved, redirected } = resolvePathInfo(path);
 
       // Virtual plugin source overrides any cache or transport version.
       if (hasVirtualFile(resolved)) {
@@ -108,13 +109,22 @@ export function createFsSync(metadataCache, contentCache, transport) {
         result = contentCache.get(resolved);
       }
 
+      // The metadata cache is kept fresh by the filewatcher and a miss here genuinely means the file is absent.
+      // Redirected paths fall through to the transport, so we can't trust the cache for them, but non-redirected misses are definitive.
+      if (result === null && !meta && !redirected) {
+        const e = new Error(
+          `ENOENT: no such file or directory, open '${path}'`,
+        );
+        e.code = "ENOENT";
+        throw e;
+      }
+
       if (result === null) {
-        // ENOENT fallback: if the resolved path doesn't exist, try the original.
-        // Covers per-name workspace files that haven't been saved yet.
+        // A resolver can map a path onto a physical target that does not exist yet, so a redirected miss retries the original path before failing.
         try {
           result = transport.readFileSync(resolved, encoding);
         } catch (e) {
-          if (resolved !== path && e.code === "ENOENT") {
+          if (redirected && e.code === "ENOENT") {
             console.warn(
               "[shim:fs] readFileSync cache miss, using sync XHR:",
               path,
@@ -206,20 +216,32 @@ export function createFsSync(metadataCache, contentCache, transport) {
       const recursive =
         typeof options === "object" ? !!options.recursive : !!options;
 
-      markLocalOp(path);
-      metadataCache.set(path, { type: "directory" });
+      const resolved = resolvePath(path);
 
-      transport.mkdir(path, recursive).catch((e) => {
-        console.error("[shim:fs] mkdirSync background create failed:", path, e);
+      markLocalOp(resolved);
+      metadataCache.set(resolved, { type: "directory" });
+
+      transport.mkdir(resolved, recursive).catch((e) => {
+        console.error(
+          "[shim:fs] mkdirSync background create failed:",
+          resolved,
+          e,
+        );
       });
     },
 
     rmdirSync(path) {
-      markLocalOp(path);
-      metadataCache.delete(path);
+      const resolved = resolvePath(path);
 
-      transport.rmdir(path).catch((e) => {
-        console.error("[shim:fs] rmdirSync background remove failed:", path, e);
+      markLocalOp(resolved);
+      metadataCache.delete(resolved);
+
+      transport.rmdir(resolved).catch((e) => {
+        console.error(
+          "[shim:fs] rmdirSync background remove failed:",
+          resolved,
+          e,
+        );
       });
     },
 

--- a/packages/shim/src/fs/transforms.js
+++ b/packages/shim/src/fs/transforms.js
@@ -12,7 +12,9 @@ export function registerPathResolver(matcher, resolver) {
   pathResolvers.push({ matcher, resolver });
 }
 
-export function resolvePath(path) {
+// resolved is the physical path.
+// redirected is true when a path resolver sent the request to a different path.
+export function resolvePathInfo(path) {
   const norm = normalize(path);
 
   for (const { matcher, resolver } of pathResolvers) {
@@ -21,13 +23,17 @@ export function resolvePath(path) {
         const resolved = resolver(norm);
 
         if (typeof resolved === "string" && resolved.length > 0) {
-          return resolved;
+          return { resolved, redirected: true };
         }
       }
     } catch {}
   }
 
-  return norm;
+  return { resolved: norm, redirected: false };
+}
+
+export function resolvePath(path) {
+  return resolvePathInfo(path).resolved;
 }
 
 // --- Read transforms ---

--- a/packages/shim/src/fs/transport.js
+++ b/packages/shim/src/fs/transport.js
@@ -19,6 +19,18 @@ function vaultId() {
   return window.__currentVaultId || "";
 }
 
+const KEEPALIVE_MAX_BYTES = 64 * 1024;
+
+// keepalive lets a request finish after the page starts unloading.
+// Its body is capped at 64KB across a shared pool, so opt in only under that limit.
+function withinKeepaliveCap(body) {
+  if (!body) {
+    return true;
+  }
+
+  return new TextEncoder().encode(body).length <= KEEPALIVE_MAX_BYTES;
+}
+
 async function request(method, endpoint, params = {}) {
   const url = new URL(API_BASE + endpoint, window.location.origin);
 
@@ -35,6 +47,11 @@ async function request(method, endpoint, params = {}) {
   } else {
     options.headers = { "Content-Type": "application/json" };
     options.body = JSON.stringify({ vault: vaultId(), ...params });
+  }
+
+  // A write (POST/DELETE) opts into keepalive so a page dismissal does not drop it.
+  if (method !== "GET" && withinKeepaliveCap(options.body)) {
+    options.keepalive = true;
   }
 
   const res = await fetch(url.toString(), options);

--- a/packages/shim/src/fs/transport.test.js
+++ b/packages/shim/src/fs/transport.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { transport } from "./transport.js";
+
+let fetchMock;
+
+beforeEach(() => {
+  fetchMock = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({}),
+    text: async () => "",
+    arrayBuffer: async () => new ArrayBuffer(0),
+  }));
+  globalThis.fetch = fetchMock;
+  globalThis.window = {
+    location: { origin: "http://localhost" },
+    __currentVaultId: "v",
+  };
+});
+
+afterEach(() => {
+  delete globalThis.fetch;
+  delete globalThis.window;
+});
+
+function lastInit() {
+  return fetchMock.mock.calls.at(-1)[1];
+}
+
+describe("transport keepalive gating", () => {
+  it("sets keepalive on a small write", async () => {
+    await transport.writeFile("a.md", "hello", "utf-8");
+
+    expect(lastInit().keepalive).toBe(true);
+  });
+
+  it("omits keepalive when the body exceeds the 64KB cap", async () => {
+    await transport.writeFile("a.md", "x".repeat(70 * 1024), "utf-8");
+
+    expect(lastInit().keepalive).toBeFalsy();
+  });
+
+  it("counts base64 inflation against the cap for binary writes", async () => {
+    // 60KB of bytes inflates to ~80KB of base64, over the cap.
+    await transport.writeFile("a.bin", new Uint8Array(60 * 1024));
+
+    expect(lastInit().keepalive).toBeFalsy();
+  });
+
+  it("sets keepalive on a bodyless delete", async () => {
+    await transport.unlink("a.md");
+
+    expect(lastInit().keepalive).toBe(true);
+  });
+
+  it("does not set keepalive on a read", async () => {
+    await transport.readFile("a.md", "utf8");
+
+    expect(lastInit().keepalive).toBeUndefined();
+  });
+});

--- a/packages/shim/src/fs/watch.js
+++ b/packages/shim/src/fs/watch.js
@@ -78,7 +78,6 @@ export function createFsWatch(transport) {
     // Internal: called when transport receives a file-change event
     _dispatch(eventType, filePath) {
       const normFile = (filePath || "").replace(/^\/+/, "");
-      let matched = false;
 
       for (const [watchPath, listeners] of watchers) {
         const normWatch = (watchPath || "").replace(/^\/+/, "");
@@ -89,7 +88,6 @@ export function createFsWatch(transport) {
           normFile.startsWith(normWatch + "/");
 
         if (isMatch) {
-          matched = true;
           const relativeName =
             normWatch === ""
               ? normFile

--- a/packages/shim/src/fs/watcher-client.js
+++ b/packages/shim/src/fs/watcher-client.js
@@ -2,8 +2,17 @@
 // The WebSocket itself is owned by ws-client.js; this module is a consumer.
 
 import { isRecentLocalOp } from "./echo-guard.js";
+import { normalize } from "../util/path.js";
 
-export function createWatcherClient(metadataCache, contentCache, fsWatch, wsClient) {
+const RESYNC_DEBOUNCE_MS = 1000;
+
+export function createWatcherClient(
+  metadataCache,
+  contentCache,
+  fsWatch,
+  wsClient,
+  transport,
+) {
   function handleCreated(msg) {
     const { path, stat } = msg;
 
@@ -72,6 +81,74 @@ export function createWatcherClient(metadataCache, contentCache, fsWatch, wsClie
   wsClient.subscribe("modified", handleModified);
   wsClient.subscribe("deleted", handleDeleted);
 
+  // Re-derive the cache from a freshly fetched tree after a reconnect.
+  // Each delta runs through the live-event handlers, matching live behavior.
+  function reconcile(tree) {
+    const fresh = new Set(Object.keys(tree).map(normalize));
+
+    for (const [path, meta] of Object.entries(tree)) {
+      const existing = metadataCache.get(path);
+
+      if (!existing) {
+        if (meta.type === "directory") {
+          handleFolderCreated({ path });
+        } else {
+          handleCreated({
+            path,
+            stat: { size: meta.size, mtime: meta.mtime, ctime: meta.ctime },
+          });
+        }
+      } else if (
+        meta.type === "file" &&
+        (existing.mtime !== meta.mtime || existing.size !== meta.size)
+      ) {
+        handleModified({
+          path,
+          stat: { size: meta.size, mtime: meta.mtime, ctime: meta.ctime },
+        });
+      }
+    }
+
+    // A cache key absent from the fresh tree was deleted while disconnected.
+    // The empty root key is preserved because the tree never lists it.
+    for (const key of metadataCache.keys()) {
+      if (key === "" || fresh.has(key)) {
+        continue;
+      }
+
+      handleDeleted({ path: key });
+    }
+  }
+
+  async function resync() {
+    let tree;
+
+    try {
+      tree = await transport.fetchTree();
+    } catch (e) {
+      console.warn("[shim:fs] reconnect resync failed:", e);
+      return;
+    }
+
+    reconcile(tree);
+  }
+
+  // Coalesce a burst of reconnects into a single resync once the socket settles.
+  let resyncTimer = null;
+
+  function scheduleResync() {
+    if (resyncTimer) {
+      clearTimeout(resyncTimer);
+    }
+
+    resyncTimer = setTimeout(() => {
+      resyncTimer = null;
+      resync();
+    }, RESYNC_DEBOUNCE_MS);
+  }
+
+  wsClient.onReconnect(scheduleResync);
+
   function connect(vaultId) {
     wsClient.connect(vaultId);
   }
@@ -83,5 +160,6 @@ export function createWatcherClient(metadataCache, contentCache, fsWatch, wsClie
   return {
     connect,
     disconnect,
+    reconcile,
   };
 }

--- a/packages/shim/src/fs/watcher-client.test.js
+++ b/packages/shim/src/fs/watcher-client.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+import { createWatcherClient } from "./watcher-client.js";
+import { markLocalOp } from "./echo-guard.js";
+
+function makeDeps() {
+  const store = new Map();
+
+  const metadataCache = {
+    get: (p) => store.get(p) || null,
+    set: (p, m) => store.set(p, m),
+    delete: (p) => store.delete(p),
+    has: (p) => store.has(p),
+    keys: () => [...store.keys()],
+  };
+
+  const contentCache = {
+    invalidate: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    get: () => null,
+  };
+
+  const fsWatch = { _dispatch: vi.fn() };
+  const wsClient = { subscribe: vi.fn(), onReconnect: vi.fn() };
+  const transport = { fetchTree: vi.fn() };
+
+  const client = createWatcherClient(
+    metadataCache,
+    contentCache,
+    fsWatch,
+    wsClient,
+    transport,
+  );
+
+  return { store, metadataCache, contentCache, fsWatch, wsClient, transport, client };
+}
+
+describe("watcher-client reconcile", () => {
+  it("adds a file present in the tree but missing from the cache", () => {
+    const d = makeDeps();
+
+    d.client.reconcile({ "new.md": { type: "file", size: 5, mtime: 100, ctime: 50 } });
+
+    expect(d.store.get("new.md")).toMatchObject({ type: "file", size: 5 });
+    expect(d.contentCache.invalidate).toHaveBeenCalledWith("new.md");
+    expect(d.fsWatch._dispatch).toHaveBeenCalledWith("created", "new.md");
+  });
+
+  it("adds a directory as a folder", () => {
+    const d = makeDeps();
+
+    d.client.reconcile({ newdir: { type: "directory" } });
+
+    expect(d.store.get("newdir")).toEqual({ type: "directory" });
+    expect(d.fsWatch._dispatch).toHaveBeenCalledWith("folder-created", "newdir");
+  });
+
+  it("modifies a file whose mtime or size changed", () => {
+    const d = makeDeps();
+    d.store.set("a.md", { type: "file", size: 1, mtime: 10 });
+
+    d.client.reconcile({ "a.md": { type: "file", size: 2, mtime: 20, ctime: 5 } });
+
+    expect(d.store.get("a.md")).toMatchObject({ size: 2, mtime: 20 });
+    expect(d.fsWatch._dispatch).toHaveBeenCalledWith("modified", "a.md");
+  });
+
+  it("is a no-op for an unchanged file", () => {
+    const d = makeDeps();
+    d.store.set("a.md", { type: "file", size: 1, mtime: 10 });
+
+    d.client.reconcile({ "a.md": { type: "file", size: 1, mtime: 10, ctime: 5 } });
+
+    expect(d.fsWatch._dispatch).not.toHaveBeenCalled();
+  });
+
+  it("deletes a cache entry absent from the tree and preserves the root", () => {
+    const d = makeDeps();
+    d.store.set("", { type: "directory" });
+    d.store.set("gone.md", { type: "file", size: 1, mtime: 10 });
+    d.store.set("keep.md", { type: "file", size: 1, mtime: 10 });
+
+    d.client.reconcile({ "keep.md": { type: "file", size: 1, mtime: 10, ctime: 5 } });
+
+    expect(d.store.has("gone.md")).toBe(false);
+    expect(d.store.has("")).toBe(true);
+    expect(d.fsWatch._dispatch).toHaveBeenCalledWith("deleted", "gone.md");
+    expect(d.fsWatch._dispatch).not.toHaveBeenCalledWith("deleted", "keep.md");
+  });
+
+  it("skips a path with a recent local op", () => {
+    const d = makeDeps();
+    const p = "recent-local-op-reconcile.md";
+    markLocalOp(p);
+
+    d.client.reconcile({ [p]: { type: "file", size: 5, mtime: 100, ctime: 50 } });
+
+    expect(d.store.has(p)).toBe(false);
+    expect(d.fsWatch._dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shim/src/globals.js
+++ b/packages/shim/src/globals.js
@@ -73,6 +73,15 @@ function installBuffer() {
 function installWindowClose() {
   window.close = function () {
     console.log("[ignis] window.close() blocked");
+
+    // Obsidian's quit flow shows the progress overlay, awaits its pending save work, then calls window.close().
+    // Since we don't actually want to close the window, we clean up the progress state instead.
+    if (document.body.classList.contains("in-progress")) {
+      document.querySelector(".progress-bar-container")?.remove();
+      document.body.classList.remove("in-progress");
+      return;
+    }
+
     if (!window.__vaultConfig) {
       showVaultManager();
     }

--- a/packages/shim/src/globals.js
+++ b/packages/shim/src/globals.js
@@ -4,7 +4,7 @@ import {
   unregisterPopupWindow,
 } from "./electron/remote/window.js";
 import { showVaultManager } from "./ui-registry.js";
-import { isSameOrigin } from "./util/url.js";
+import { isSameOrigin, isDirectFetchHost } from "./util/url.js";
 import { proxyFetch } from "./util/proxy.js";
 
 function installProcess() {
@@ -143,7 +143,7 @@ function installFetchShim() {
       url = String(input);
     }
 
-    if (isSameOrigin(url)) {
+    if (isSameOrigin(url) || isDirectFetchHost(url)) {
       return originalFetch(input, init);
     }
 

--- a/packages/shim/src/init.js
+++ b/packages/shim/src/init.js
@@ -208,8 +208,27 @@ function initCoreSyncGuardFallback() {
   }
 }
 
+// Reflect the priority prefetch's byte progress on the boot splash so the awaited slice reads as active rather than hung.
+// The splash logo keeps pulsing through a transit stall, when the byte count would otherwise freeze.
+function updateBootProgress(received, total) {
+  // Once the injector starts appending Obsidian's scripts it owns the splash label, so stop writing progress over it.
+  if (window.__ignisBootStarted) {
+    return;
+  }
+
+  const label = document.getElementById("ignis-status-label");
+
+  if (!label || !total) {
+    return;
+  }
+
+  const mb = (n) => (n / (1024 * 1024)).toFixed(1);
+  label.textContent = `Loading plugins... ${mb(received)}/${mb(total)} MB`;
+}
+
 export function initialize() {
   if (maybeProvisionDemoVault()) {
+    window.__ignisBootReady = Promise.resolve();
     return;
   }
 
@@ -229,14 +248,19 @@ export function initialize() {
     bootstrapVirtualPlugins = bootstrap.virtualPlugins || [];
     applyServerSettings(bootstrap.settings);
 
-    // Race the indexer: batch-fetch text content into ContentCache so
-    // Obsidian's startup indexing reads hit the cache instead of the network.
-    prefetchVaultContent(
+    // Warm the caches before Obsidian boots.
+    // The priority slice (configs and plugin entry files) resolves window.__ignisBootReady, which the index.html injector waits on before appending Obsidian's scripts, so Obsidian's early reads hit the cache.
+    // The bulk slice streams afterward without blocking boot.
+    const { priority } = prefetchVaultContent(
       window.__currentVaultId,
       bootstrap.tree,
       fsShim._contentCache,
+      { onProgress: updateBootProgress },
     );
+
+    window.__ignisBootReady = priority;
   } else {
+    window.__ignisBootReady = Promise.resolve();
     initVaultConfigFallback();
     initVaultListFallback();
     initMetadataCacheFallback();

--- a/packages/shim/src/init.js
+++ b/packages/shim/src/init.js
@@ -122,7 +122,7 @@ function initVaultConfigFallback() {
 function initVaultListFallback() {
   try {
     vaultService.listVaultsSync();
-  } catch (e) {
+  } catch {
     window.__vaultList = [];
   }
 }

--- a/packages/shim/src/init.js
+++ b/packages/shim/src/init.js
@@ -171,8 +171,7 @@ function applyCoreSyncGuard(plugins) {
       return data;
     }
 
-    let text =
-      typeof data === "string" ? data : new TextDecoder().decode(data);
+    let text = typeof data === "string" ? data : new TextDecoder().decode(data);
 
     try {
       const config = JSON.parse(text);
@@ -226,6 +225,13 @@ function updateBootProgress(received, total) {
   label.textContent = `Loading plugins... ${mb(received)}/${mb(total)} MB`;
 }
 
+// Resolve the active workspace and snapshot the appearance config.
+function resolveWorkspaceAndAppearance() {
+  resolveWorkspaceName();
+  loadPresetIfRequested();
+  initNativeMenuGuard();
+}
+
 export function initialize() {
   if (maybeProvisionDemoVault()) {
     window.__ignisBootReady = Promise.resolve();
@@ -233,9 +239,6 @@ export function initialize() {
   }
 
   resolveVaultId();
-  resolveWorkspaceName();
-  loadPresetIfRequested();
-  initNativeMenuGuard(window.__currentVaultId);
 
   const bootstrap = fetchBootstrap();
 
@@ -258,13 +261,16 @@ export function initialize() {
       { onProgress: updateBootProgress },
     );
 
-    window.__ignisBootReady = priority;
+    // Chain workspace/appearance resolution onto readiness so its config reads hit the warm priority slice instead of the network.
+    window.__ignisBootReady = priority.then(resolveWorkspaceAndAppearance);
   } else {
-    window.__ignisBootReady = Promise.resolve();
     initVaultConfigFallback();
     initVaultListFallback();
     initMetadataCacheFallback();
     initCoreSyncGuardFallback();
+    // No prefetch on the fallback path, so resolve directly; the reads fall through to the network.
+    resolveWorkspaceAndAppearance();
+    window.__ignisBootReady = Promise.resolve();
   }
 
   installRequestUrlShim();

--- a/packages/shim/src/init.js
+++ b/packages/shim/src/init.js
@@ -6,6 +6,7 @@ import {
   resolveWorkspaceName,
   loadPresetIfRequested,
   initWorkspacePatch,
+  isValidWorkspaceName,
 } from "./workspace.js";
 import { prefetchVaultContent } from "./fs/indexer-prefetch.js";
 import { setInputCacheLimits } from "./fs/input-cache.js";
@@ -36,7 +37,9 @@ function resolveVaultId() {
   const urlParams = new URLSearchParams(window.location.search);
   window.__currentVaultId =
     urlParams.get("vault") || localStorage.getItem("last-vault") || "";
-  window.__workspaceName = urlParams.get("workspace") || "";
+
+  const workspace = urlParams.get("workspace") || "";
+  window.__workspaceName = isValidWorkspaceName(workspace) ? workspace : "";
 }
 
 // Single round-trip bootstrap: vault info + vault list + metadata tree + plugins.

--- a/packages/shim/src/init.js
+++ b/packages/shim/src/init.js
@@ -10,13 +10,15 @@ import {
 } from "./workspace.js";
 import { prefetchVaultContent } from "./fs/indexer-prefetch.js";
 import { setInputCacheLimits } from "./fs/input-cache.js";
+import { setDirectFetchHosts } from "./util/url.js";
 import { autoTrustDemoVaults, maybeProvisionDemoVault } from "./demo.js";
 import { initNativeMenuGuard } from "./native-menu-guard.js";
 
 let bootstrapVirtualPlugins = [];
 
-// Cache sizes come from the bootstrap response and are applied at page load.
-// The server owns the rest of the settings and applies them on its side.
+// Settings the client must act on come from the bootstrap response and are applied at page load.
+// This includes cache sizes, and the hosts the browser fetches directly instead of via the proxy.
+// The server owns and enforces the rest.
 function applyServerSettings(s) {
   if (!s) {
     return;
@@ -27,6 +29,7 @@ function applyServerSettings(s) {
   }
 
   setInputCacheLimits({ maxSize: s.inputCacheBytes, ttlMs: s.inputCacheTtlMs });
+  setDirectFetchHosts(s.directFetchHosts);
 }
 
 export function getBootstrapVirtualPlugins() {

--- a/packages/shim/src/native-menu-guard.js
+++ b/packages/shim/src/native-menu-guard.js
@@ -6,34 +6,16 @@ import {
   registerReadTransform,
   registerWriteTransform,
 } from "./fs/transforms.js";
+import { fsShim } from "./fs/index.js";
 
 const APPEARANCE_PATH = ".obsidian/appearance.json";
 
 // undefined = key absent on disk; write transform keeps it absent.
 let preservedNativeMenus = undefined;
 
-function snapshotAppearance(vaultId) {
-  if (!vaultId) {
-    return;
-  }
-
+function snapshotAppearance() {
   try {
-    const xhr = new XMLHttpRequest();
-    const url =
-      "/api/fs/readFile?vault=" +
-      encodeURIComponent(vaultId) +
-      "&path=" +
-      encodeURIComponent(APPEARANCE_PATH) +
-      "&encoding=utf-8";
-
-    xhr.open("GET", url, false);
-    xhr.send();
-
-    if (xhr.status !== 200) {
-      return;
-    }
-
-    const obj = JSON.parse(xhr.responseText);
+    const obj = JSON.parse(fsShim.readFileSync(APPEARANCE_PATH, "utf-8"));
 
     if ("nativeMenus" in obj) {
       preservedNativeMenus = obj.nativeMenus;
@@ -158,9 +140,9 @@ function disableNativeMenuToggle() {
   });
 }
 
-export function initNativeMenuGuard(vaultId) {
-  // Snapshot before registering transforms so the write transform has the original disk value to substitute back.
-  snapshotAppearance(vaultId);
+export function initNativeMenuGuard() {
+  // Snapshot before registering the read transform so the captured value is the original on disk, not the forced value.
+  snapshotAppearance();
   registerReadTransform(APPEARANCE_PATH, readTransform);
   registerWriteTransform(APPEARANCE_PATH, writeTransform);
   patchSetConfig();

--- a/packages/shim/src/node/events.js
+++ b/packages/shim/src/node/events.js
@@ -30,6 +30,8 @@ export class EventEmitter {
       return false;
     }
 
+    // Iterate a snapshot: a once-listener removes itself from this array during emit, which would corrupt a live iteration.
+    // eslint-disable-next-line unicorn/no-useless-spread
     for (const fn of [...listeners]) {
       fn.apply(this, args);
     }

--- a/packages/shim/src/request-url.js
+++ b/packages/shim/src/request-url.js
@@ -54,15 +54,12 @@ function makeResponse(request, status, headers, arrayBuf) {
 export function installRequestUrlShim() {
   // Obsidian sets window.requestUrl in app.js. We override it once the page loads.
   // Use a getter so it intercepts even if app.js sets it later.
-  let _original = null;
-
   Object.defineProperty(window, "requestUrl", {
     get() {
       return proxyRequestUrl;
     },
-    set(val) {
-      _original = val;
-    },
+    // Swallow Obsidian's later assignment so the shim keeps serving its own requestUrl.
+    set() {},
     configurable: true,
   });
 }

--- a/packages/shim/src/request-url.js
+++ b/packages/shim/src/request-url.js
@@ -1,7 +1,7 @@
 // Override window.requestUrl to proxy external requests through our server, bypassing CORS.
 // Obsidian sets window.requestUrl in app.js, so we override it after app.js loads.
 
-import { isSameOrigin } from "./util/url.js";
+import { isSameOrigin, isDirectFetchHost } from "./util/url.js";
 import { proxyFetch } from "./util/proxy.js";
 
 async function proxyRequestUrl(request) {
@@ -9,8 +9,8 @@ async function proxyRequestUrl(request) {
     request = { url: request };
   }
 
-  // Same-origin requests don't need the proxy.
-  if (isSameOrigin(request.url)) {
+  // Same-origin requests don't need the proxy, and allowlisted hosts are fetched directly.
+  if (isSameOrigin(request.url) || isDirectFetchHost(request.url)) {
     const res = await fetch(request.url, {
       method: request.method || "GET",
       headers: request.headers || {},

--- a/packages/shim/src/util/url.js
+++ b/packages/shim/src/util/url.js
@@ -21,4 +21,31 @@ function isSameOrigin(url) {
   }
 }
 
-export { isSameOrigin };
+// Hosts the user marked safe to fetch directly from the browser, bypassing the proxy.
+// Populated at boot from the server settings, matched by exact hostname (case-insensitive).
+let directFetchHosts = new Set();
+
+function setDirectFetchHosts(list) {
+  directFetchHosts = new Set(
+    (Array.isArray(list) ? list : [])
+      .map((host) => String(host).trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+// True when a request URL's host is on the direct-fetch list.
+// The browser fetches it itself (subject to CORS) instead of routing through the server proxy.
+function isDirectFetchHost(url) {
+  if (directFetchHosts.size === 0) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url, window.location.origin);
+    return directFetchHosts.has(parsed.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+export { isSameOrigin, setDirectFetchHosts, isDirectFetchHost };

--- a/packages/shim/src/util/url.test.js
+++ b/packages/shim/src/util/url.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { isSameOrigin } from "./url.js";
+import { isSameOrigin, setDirectFetchHosts, isDirectFetchHost } from "./url.js";
 
 describe("isSameOrigin", () => {
   beforeEach(() => {
@@ -21,5 +21,48 @@ describe("isSameOrigin", () => {
   it("matches the page origin and rejects a different host", () => {
     expect(isSameOrigin("https://vault.example.com/x")).toBe(true);
     expect(isSameOrigin("https://evil.com/x")).toBe(false);
+  });
+});
+
+describe("isDirectFetchHost", () => {
+  beforeEach(() => {
+    global.window = { location: { origin: "https://vault.example.com" } };
+  });
+
+  afterEach(() => {
+    setDirectFetchHosts([]);
+    delete global.window;
+  });
+
+  it("is false when no hosts are configured", () => {
+    expect(isDirectFetchHost("https://api.example.com/x")).toBe(false);
+  });
+
+  it("matches a configured host exactly", () => {
+    setDirectFetchHosts(["api.example.com"]);
+    expect(isDirectFetchHost("https://api.example.com/path")).toBe(true);
+  });
+
+  it("does not match a host that merely contains a configured host", () => {
+    setDirectFetchHosts(["immersivetranslate.com"]);
+    expect(isDirectFetchHost("https://evil-immersivetranslate.com/x")).toBe(
+      false,
+    );
+  });
+
+  it("matches case-insensitively and trims entries", () => {
+    setDirectFetchHosts([" API.Example.com "]);
+    expect(isDirectFetchHost("https://api.example.com/x")).toBe(true);
+  });
+
+  it("rejects a host not on the list", () => {
+    setDirectFetchHosts(["api.example.com"]);
+    expect(isDirectFetchHost("https://other.com/x")).toBe(false);
+  });
+
+  it("returns false for a relative or empty URL", () => {
+    setDirectFetchHosts(["api.example.com"]);
+    expect(isDirectFetchHost("/api/fs/readFile")).toBe(false);
+    expect(isDirectFetchHost("")).toBe(false);
   });
 });

--- a/packages/shim/src/workspace.js
+++ b/packages/shim/src/workspace.js
@@ -8,6 +8,11 @@ import {
 const WORKSPACE_PATH = ".obsidian/workspace.json";
 const WORKSPACES_PATH = ".obsidian/workspaces.json";
 
+// A workspace name from the URL flows into the per-workspace state-file path, so constrain it.
+export function isValidWorkspaceName(name) {
+  return /^[A-Za-z0-9 _.-]{1,64}$/.test(name);
+}
+
 // Redirect workspace.json to a per-name file when a workspace is active in this tab.
 registerPathResolver(
   (path) => path === WORKSPACE_PATH && !!window.__workspaceName,

--- a/packages/shim/src/workspace.js
+++ b/packages/shim/src/workspace.js
@@ -86,71 +86,40 @@ export function loadPresetIfRequested() {
   }
 }
 
-export function resolveWorkspaceName() {
+function readJsonIfPresent(path) {
   try {
-    const vaultParam = window.__currentVaultId
-      ? "?vault=" + encodeURIComponent(window.__currentVaultId)
-      : "";
+    return JSON.parse(fsShim.readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
 
-    const sep = vaultParam ? "&" : "?";
+export function resolveWorkspaceName() {
+  // With no URL param, only resolve a workspace when the workspaces core plugin is enabled.
+  if (!window.__workspaceName) {
+    const corePlugins = readJsonIfPresent(".obsidian/core-plugins.json");
 
-    // If no param provided, check if workspaces plugin is enabled before resolving.
-    if (!window.__workspaceName) {
-      const coreXhr = new XMLHttpRequest();
-
-      coreXhr.open(
-        "GET",
-        "/api/fs/readFile" +
-          vaultParam +
-          sep +
-          "path=.obsidian/core-plugins.json&encoding=utf-8",
-        false,
-      );
-      coreXhr.send();
-
-      if (coreXhr.status !== 200) {
-        return;
-      }
-
-      const corePlugins = JSON.parse(coreXhr.responseText);
-
-      if (!corePlugins.workspaces) {
-        return;
-      }
-    }
-
-    // Read workspaces.json to get the active field.
-    const xhr = new XMLHttpRequest();
-
-    xhr.open(
-      "GET",
-      "/api/fs/readFile" +
-        vaultParam +
-        sep +
-        "path=.obsidian/workspaces.json&encoding=utf-8",
-      false,
-    );
-    xhr.send();
-
-    if (xhr.status !== 200) {
+    if (!corePlugins || !corePlugins.workspaces) {
       return;
     }
+  }
 
-    const workspaces = JSON.parse(xhr.responseText);
+  const workspaces = readJsonIfPresent(WORKSPACES_PATH);
 
-    // Always store the original active value for the write transform.
-    if (workspaces.active) {
-      window.__originalActiveWorkspace = workspaces.active;
-    }
+  if (!workspaces) {
+    return;
+  }
 
-    // If no param was provided, seed from the active workspace.
-    if (!window.__workspaceName && workspaces.active) {
-      window.__workspaceName = workspaces.active;
-      setWorkspaceParam(workspaces.active);
-      console.log("[ignis] Workspace resolved from active:", workspaces.active);
-    }
-  } catch (e) {
-    console.warn("[ignis] Failed to resolve workspace name:", e);
+  // Keep the original active value so the write transform can restore it on disk.
+  if (workspaces.active) {
+    window.__originalActiveWorkspace = workspaces.active;
+  }
+
+  // With no URL param, seed from the active workspace.
+  if (!window.__workspaceName && workspaces.active) {
+    window.__workspaceName = workspaces.active;
+    setWorkspaceParam(workspaces.active);
+    console.log("[ignis] Workspace resolved from active:", workspaces.active);
   }
 }
 

--- a/packages/shim/src/workspace.test.js
+++ b/packages/shim/src/workspace.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { isValidWorkspaceName } from "./workspace.js";
+
+describe("isValidWorkspaceName", () => {
+  it("accepts normal workspace names", () => {
+    expect(isValidWorkspaceName("Cooking")).toBe(true);
+    expect(isValidWorkspaceName("My Workspace_1.2-3")).toBe(true);
+  });
+
+  it("rejects empty, over-long, and path-bearing names", () => {
+    expect(isValidWorkspaceName("")).toBe(false);
+    expect(isValidWorkspaceName("x".repeat(65))).toBe(false);
+    expect(isValidWorkspaceName("../etc")).toBe(false);
+    expect(isValidWorkspaceName("a\\b")).toBe(false);
+  });
+});

--- a/packages/shim/src/ws-client.js
+++ b/packages/shim/src/ws-client.js
@@ -204,7 +204,7 @@ export function createWsClient() {
   }
 
   function send(type, payload) {
-    postRaw({ type, ...(payload || {}) });
+    postRaw({ type, ...payload });
   }
 
   function channel(name) {
@@ -251,7 +251,7 @@ export function createWsClient() {
       },
 
       send(type, payload) {
-        postRaw({ channel: name, type, ...(payload || {}) });
+        postRaw({ channel: name, type, ...payload });
       },
     };
   }

--- a/packages/shim/src/ws-client.js
+++ b/packages/shim/src/ws-client.js
@@ -8,12 +8,14 @@ export function createWsClient() {
   let vaultId = null;
   let reconnectTimer = null;
   let manuallyClosed = false;
+  let hasConnectedBefore = false;
   let state = "closed"; // "closed" | "connecting" | "open"
 
   const globalSubs = new Map(); // type -> Set<handler>
   const channelSubs = new Map(); // channelName -> Map<type, Set<handler>>
   const channelSubCount = new Map(); // channelName -> integer
   const stateSubs = new Set(); // handler(state)
+  const reconnectSubs = new Set(); // handler() fired on a re-open, not the first open
 
   function setState(next) {
     if (state === next) {
@@ -106,6 +108,20 @@ export function createWsClient() {
       // Re-establish channel subscriptions on the new connection.
       for (const name of channelSubCount.keys()) {
         sendSubscribeChannel(name);
+      }
+
+      // A re-open can miss watcher events that fired while the socket was down.
+      // Boot covers the first open, so handlers fire only on later opens.
+      if (hasConnectedBefore) {
+        for (const fn of reconnectSubs) {
+          try {
+            fn();
+          } catch (e) {
+            console.error("[ws] reconnect subscriber threw:", e);
+          }
+        }
+      } else {
+        hasConnectedBefore = true;
       }
     };
 
@@ -252,6 +268,14 @@ export function createWsClient() {
     };
   }
 
+  function onReconnect(handler) {
+    reconnectSubs.add(handler);
+
+    return () => {
+      reconnectSubs.delete(handler);
+    };
+  }
+
   return {
     connect,
     disconnect,
@@ -260,6 +284,7 @@ export function createWsClient() {
     channel,
     isOpen,
     onStateChange,
+    onReconnect,
   };
 }
 

--- a/packages/shim/src/ws-client.test.js
+++ b/packages/shim/src/ws-client.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createWsClient } from "./ws-client.js";
+
+let sockets;
+
+beforeEach(() => {
+  sockets = [];
+
+  class FakeWebSocket {
+    constructor(url) {
+      this.url = url;
+      this.readyState = 0;
+      sockets.push(this);
+    }
+    send() {}
+    close() {}
+  }
+
+  FakeWebSocket.OPEN = 1;
+  globalThis.WebSocket = FakeWebSocket;
+  globalThis.window = { location: { protocol: "http:", host: "localhost" } };
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  delete globalThis.WebSocket;
+  delete globalThis.window;
+});
+
+describe("ws-client reconnect", () => {
+  it("fires onReconnect on a re-open but not on the first open", () => {
+    const client = createWsClient();
+    const onReconnect = vi.fn();
+    client.onReconnect(onReconnect);
+
+    client.connect("v1");
+    sockets[0].onopen();
+    expect(onReconnect).not.toHaveBeenCalled();
+
+    sockets[0].onclose();
+    vi.advanceTimersByTime(2000);
+    sockets[1].onopen();
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops firing after unsubscribe", () => {
+    const client = createWsClient();
+    const onReconnect = vi.fn();
+    const off = client.onReconnect(onReconnect);
+
+    client.connect("v1");
+    sockets[0].onopen();
+    off();
+
+    sockets[0].onclose();
+    vi.advanceTimersByTime(2000);
+    sockets[1].onopen();
+
+    expect(onReconnect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/bootstrap.js
+++ b/packages/ui/src/bootstrap.js
@@ -1,4 +1,5 @@
 import { vaultService } from "@ignis/services";
+import InsecureContextNotice from "./components/layout/InsecureContextNotice.svelte";
 
 function showVaultManager() {
   if (document.querySelector(".vault-manager-overlay")) return;
@@ -23,12 +24,7 @@ function showMessageDialog(title, message) {
   });
 }
 
-function showConfirmDialog(
-  title,
-  message,
-  description,
-  confirmText = "OK",
-) {
+function showConfirmDialog(title, message, description, confirmText = "OK") {
   return new Promise((resolve) => {
     const dialog = new window.IgnisUI.ConfirmDialog({
       target: document.body,
@@ -83,4 +79,29 @@ if (typeof window !== "undefined" && window.__ignis_registerUI) {
   console.warn(
     "[ignis] __ignis_registerUI not available; UI handlers not registered",
   );
+}
+
+// On a non-secure context the browser gates certain APIs causing certain features to break.
+// Show a notice about the degraded experience and how to fix it.
+function showInsecureContextNotice() {
+  if (window.isSecureContext) {
+    return;
+  }
+
+  if (document.getElementById("ignis-insecure-banner")) {
+    return;
+  }
+
+  const notice = new InsecureContextNotice({ target: document.body });
+  notice.$on("dismiss", () => notice.$destroy());
+}
+
+if (typeof window !== "undefined") {
+  if (document.body) {
+    showInsecureContextNotice();
+  } else {
+    window.addEventListener("DOMContentLoaded", showInsecureContextNotice, {
+      once: true,
+    });
+  }
 }

--- a/packages/ui/src/components/layout/Banner.svelte
+++ b/packages/ui/src/components/layout/Banner.svelte
@@ -1,0 +1,109 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+  import { X } from "lucide-svelte";
+
+  export let severity = "info";
+  export let dismissible = true;
+  export let title = "";
+  export let id = undefined;
+
+  const dispatch = createEventDispatcher();
+
+  function dismiss() {
+    dispatch("dismiss");
+  }
+</script>
+
+<div class="banner {severity}" {id} role="alert">
+  <div class="banner-body">
+    {#if title}
+      <strong class="banner-title">{title}</strong>
+    {/if}
+    <slot />
+  </div>
+
+  {#if dismissible}
+    <button
+      class="banner-close"
+      on:click={dismiss}
+      aria-label="Dismiss"
+      title="Dismiss"
+    >
+      <X size="1.125rem" />
+    </button>
+  {/if}
+</div>
+
+<style>
+  .banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 2147483647;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 1rem;
+    font-family: var(
+      --font-interface,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif
+    );
+    font-size: 0.8125rem;
+    line-height: 1.45;
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
+
+    user-select: text;
+    -webkit-user-select: text;
+  }
+
+  .banner-body {
+    flex: 1;
+  }
+
+  .banner-title {
+    display: block;
+    font-weight: 600;
+  }
+
+  .banner-close {
+    flex-shrink: 0;
+    align-self: flex-start;
+    display: flex;
+    align-items: center;
+    background: none;
+    border: none;
+    box-shadow: none;
+    color: inherit;
+    opacity: 0.8;
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 0.25rem;
+  }
+
+  .banner-close:hover {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.2);
+  }
+
+  .error {
+    background: #5c1a1a;
+    color: #f3d6d6;
+    border-bottom: 1px solid #7a2a2a;
+  }
+
+  .warning {
+    background: #5c4410;
+    color: #f3e6c0;
+    border-bottom: 1px solid #7a5e1a;
+  }
+
+  .info {
+    background: #13304d;
+    color: #cfe2f3;
+    border-bottom: 1px solid #1d4a73;
+  }
+</style>

--- a/packages/ui/src/components/layout/InsecureContextNotice.svelte
+++ b/packages/ui/src/components/layout/InsecureContextNotice.svelte
@@ -1,0 +1,48 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+  import Banner from "./Banner.svelte";
+
+  const dispatch = createEventDispatcher();
+  const origin = window.location.origin;
+
+  function onDismiss() {
+    dispatch("dismiss");
+  }
+</script>
+
+<Banner
+  id="ignis-insecure-banner"
+  severity="error"
+  title="Insecure connection: some features are broken."
+  on:dismiss={onDismiss}
+>
+  <div class="detail">
+    This page is served over plain HTTP, so the browser disables several APIs
+    (crypto, clipboard, etc) that Obsidian relies on. Several features will not
+    work, including graph view, outlines, certain clipboard operations, and
+    more.
+  </div>
+  <div class="fix">
+    Fix it by serving Ignis over HTTPS (a TLS reverse proxy or
+    <code>tailscale serve</code>). As a local workaround, add this origin to
+    <code>chrome://flags/#unsafely-treat-insecure-origin-as-secure</code> and
+    relaunch the browser: <code class="origin">{origin}</code>
+  </div>
+</Banner>
+
+<style>
+  .detail {
+    margin-top: 0.25rem;
+  }
+
+  .fix {
+    margin-top: 0.375rem;
+  }
+
+  code {
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.3);
+    font-family: var(--font-monospace, ui-monospace, monospace);
+  }
+</style>

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -4,4 +4,5 @@ export { default as VaultManager } from "./views/VaultManager.svelte";
 export { default as MessageDialog } from "./components/layout/MessageDialog.svelte";
 export { default as ConfirmDialog } from "./components/layout/ConfirmDialog.svelte";
 export { default as PromptDialog } from "./components/layout/PromptDialog.svelte";
+export { default as Banner } from "./components/layout/Banner.svelte";
 export { default as SyncSetupModal } from "./views/SyncSetupModal.svelte";

--- a/scripts/check-error-leaks.mjs
+++ b/scripts/check-error-leaks.mjs
@@ -1,0 +1,84 @@
+// Guards the error-message leak class.
+// `error: e.message` in a server response leaks internal details (absolute paths, stack hints) to HTTP clients.
+// sanitizeError(e) is the safe form. Use `leak-allow` to mark a deliberately-safe message.
+// Runs as part of `npm run lint`.
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const ROOTS = ["apps/ignis-server/server", "packages/server-core/src"];
+const PATTERN = /error:\s*[A-Za-z_$][\w$]*\.message\b/;
+const ALLOW = "leak-allow";
+
+function walk(dir, out) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name !== "node_modules" && entry.name !== "dist") {
+        walk(full, out);
+      }
+
+      continue;
+    }
+
+    if (/\.(js|mjs|cjs)$/.test(entry.name) && !/\.test\./.test(entry.name)) {
+      out.push(full);
+    }
+  }
+}
+
+const files = [];
+
+for (const root of ROOTS) {
+  try {
+    walk(root, files);
+  } catch {
+    // A missing root is not this check's concern.
+  }
+}
+
+const violations = [];
+
+for (const file of files) {
+  const lines = readFileSync(file, "utf8").split("\n");
+
+  lines.forEach((line, i) => {
+    const trimmed = line.trim();
+
+    // Skip comments so prose that mentions the pattern does not trip the check.
+    if (trimmed.startsWith("//") || trimmed.startsWith("*")) {
+      return;
+    }
+
+    if (!PATTERN.test(line)) {
+      return;
+    }
+
+    const prev = i > 0 ? lines[i - 1] : "";
+
+    if (line.includes(ALLOW) || prev.includes(ALLOW)) {
+      return;
+    }
+
+    violations.push(`${file}:${i + 1}: ${trimmed}`);
+  });
+}
+
+if (violations.length > 0) {
+  console.error(
+    "error-leak check: `error: e.message` reached a response without a `leak-allow` marker.",
+  );
+  console.error(
+    "Use sanitizeError(e), or mark the line with `leak-allow` when the message is deliberately safe.\n",
+  );
+
+  for (const v of violations) {
+    console.error("  " + v);
+  }
+
+  process.exit(1);
+}
+
+console.log(`error-leak check: clean (${files.length} files scanned).`);


### PR DESCRIPTION
## 0.8.7 (Karm)

- direct-fetch host allowlist for fetching CORS-friendly hosts straight from the browser, bypassing the proxy
- insecure-context warning banner when served over plain http, where browser crypto/clipboard apis are disabled (graph view, outline, sync, etc.)
- faster cold loads: prefetch warms the cache before obsidian boots, and static assets are served immutable
- websocket heartbeat keeps live-sync alive through idle proxies, with metadata resync on reconnect
- small writes survive page dismissal via fetch keepalive

security/hygiene:

- error responses no longer leak absolute server paths
- ?workspace= validation, zip export skips symlinks, demo name/quota hardening
- shim fs fixes: missing reads answered from cache, mkdir/rmdir path resolution
- window.close no longer strands you on obsidian's "saving" overlay

internal:

- added oxlint linting

closes #30, #31, #33.