### PR TITLE
0.8.8: boot performance, write durability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.8] - Karm (2026-07-05)
+
+### Added
+
+- Failed writes are retried in the background, with a status bar item for pending and failed writes.
+- A symlink under `VAULT_ROOT` pointing at a directory is discovered as a vault.
+
+### Changed
+
+- Boot prefetch skips plugin asset directories and reads batches in parallel.
+- A `chown` that fails on startup (read-only or NFS `root_squash` mounts) logs a warning instead of aborting.
+- The "Spellcheck languages" setting is disabled, with a link to the browser's own language settings.
+
+### Fixed
+
+- WebDAV uploads through the cross-origin proxy no longer corrupt; the proxy recomputes `Content-Length` for the request body.
+
+### Security
+
+- `resolveVaultPath` resolves symlinks and confines each access to the vault's real path.
+
 ## [0.8.7] - Karm (2026-06-19)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,10 +9,19 @@
     Run Obsidian in the browser. No remote desktop required.
   </p>
 
+  <h3 align="center">
+    <a href="apps/ignis-server/README.md">Setup instructions</a>
+  </h3>
+
   <p align="center">
     <a href="https://ignis-demo.thiefling.com">Try the live demo</a>
   </p>
 </section>
+
+## Getting started
+
+> [!TIP]
+> **[Setup instructions](apps/ignis-server/README.md)** for the self-hosted Docker server.
 
 ## What is this
 
@@ -52,6 +61,7 @@ Ignis currently ships as a self-hosted server but I have plans for a desktop plu
 - Streaming `zlib` classes (`createGzip`, `createDeflate`, etc.) aren't implemented. The synchronous and callback variants work via `pako`.
 - The synchronous file picker (`dialog.showOpenDialogSync`), used by plugins like Importer, has a staged-files workaround: the shim asks you to pick once and serves the result on retry. Usable but rough.
 - `safeStorage` is passthrough by design: `isEncryptionAvailable()` returns `false` and `encrypt`/`decrypt` are no-ops. Anything plugins store via `safeStorage` ends up as plaintext on disk. A server-side encrypted option is planned but not yet implemented; until then, treat anything `safeStorage` produces the same as anything else in the vault.
+- Spellcheck language selection from Obsidian's settings doesn't work: a web page can't set the browser's spellchecker languages, so the "Spellcheck languages" setting is disabled and points you to your browser's own language settings instead.
 
 Compatibility for specific community plugins is tracked in [Issue #9](https://github.com/Nystik-gh/ignis/issues/9).
 

--- a/apps/ignis-server/Dockerfile
+++ b/apps/ignis-server/Dockerfile
@@ -19,7 +19,8 @@ COPY build.js ./
 COPY packages/ ./packages/
 COPY apps/ignis-server/ ./apps/ignis-server/
 
-RUN npm run build
+ARG IGNIS_BUILD
+RUN IGNIS_BUILD=${IGNIS_BUILD} npm run build
 
 # Production image. No Obsidian code included.
 # On first run, the entrypoint downloads Obsidian.

--- a/apps/ignis-server/README.md
+++ b/apps/ignis-server/README.md
@@ -83,6 +83,10 @@ To build from source instead of pulling the image, clone the repo and run `docke
 | `/app/data` | State persistence for various Ignis-specific functionality: plugin management, headless sync config, etc. |
 | `/app/obsidian-app` | Cached Obsidian assets. Persisting this avoids re-downloading on container recreate. |
 
+### Ownership on NFS shares
+
+For NFS shares with `root_squash`, set the share's owner to `PUID`/`PGID` or export the share with `no_root_squash`, so that `PUID`/`PGID` can read and write `/vaults`, `/app/data`, and `/app/obsidian-app`. The container chowns these paths to `PUID`/`PGID` at startup, which `root_squash` blocks. When the chown fails, the container still runs, and file access falls to the mount's own permissions, so Ignis works only where `PUID`/`PGID` can already read and write.
+
 ## Environment Variables
 
 | Variable | Description | Default |

--- a/apps/ignis-server/scripts/entrypoint.sh
+++ b/apps/ignis-server/scripts/entrypoint.sh
@@ -25,7 +25,10 @@ fi
 
 
 mkdir -p /app/data
-chown -R "$PUID:$PGID" /vaults /app/obsidian-app /app/data
+# Best-effort: a read-only or root_squash mount forbids chown, but PUID/PGID may already have access.
+for dir in /app/obsidian-app /app/data /vaults; do
+  chown -R "$PUID:$PGID" "$dir" 2>/dev/null || echo "[ignis] WARNING: could not chown $dir (read-only mount or NFS root_squash); continuing. Ensure PUID/PGID can read+write it."
+done
 
 OBSIDIAN_DIR="/app/obsidian-app"
 OBSIDIAN_VERSION="${OBSIDIAN_VERSION:-1.12.7}"

--- a/apps/ignis-server/server/config.js
+++ b/apps/ignis-server/server/config.js
@@ -29,7 +29,26 @@ function discoverVaults() {
     const entries = fs.readdirSync(vaultRoot, { withFileTypes: true });
 
     for (const entry of entries) {
-      if (entry.isDirectory() && !entry.name.startsWith(".")) {
+      if (entry.name.startsWith(".")) {
+        continue;
+      }
+
+      let isDir = entry.isDirectory();
+
+      // A symlink Dirent reports the link's type, not the target's, so follow it to find symlinked vaults.
+      if (!isDir && entry.isSymbolicLink()) {
+        try {
+          isDir = fs.statSync(path.join(vaultRoot, entry.name)).isDirectory();
+        } catch (e) {
+          console.error(
+            "[config] Skipping unreadable vault entry:",
+            entry.name,
+            e.message,
+          );
+        }
+      }
+
+      if (isDir) {
         vaults[entry.name] = path.join(vaultRoot, entry.name);
       }
     }

--- a/apps/ignis-server/server/config.test.mjs
+++ b/apps/ignis-server/server/config.test.mjs
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const CONFIG_ID = require.resolve("./config.js");
+
+// Symlink creation needs privilege or Developer Mode on Windows; skip those cases where it fails.
+let canSymlink = false;
+try {
+  const probe = fs.mkdtempSync(path.join(os.tmpdir(), "ignis-symlink-probe-"));
+  fs.symlinkSync(probe, path.join(probe, "l"), "dir");
+  canSymlink = true;
+  fs.rmSync(probe, { recursive: true, force: true });
+} catch {
+  canSymlink = false;
+}
+
+let root;
+let target;
+let dataRoot;
+
+function loadVaults() {
+  process.env.VAULT_ROOT = root;
+  process.env.DATA_ROOT = dataRoot;
+  delete process.env.AUTO_CREATE_DEFAULT;
+  delete require.cache[CONFIG_ID];
+  return require("./config.js").vaults;
+}
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "ignis-vaultroot-"));
+  target = fs.mkdtempSync(path.join(os.tmpdir(), "ignis-linktarget-"));
+  dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ignis-dataroot-"));
+
+  fs.mkdirSync(path.join(root, "realvault"));
+  fs.mkdirSync(path.join(root, ".hidden"));
+  fs.writeFileSync(path.join(root, "notavault.md"), "x");
+
+  if (canSymlink) {
+    fs.symlinkSync(target, path.join(root, "linkvault"), "dir");
+    fs.symlinkSync(path.join(target, "nope"), path.join(root, "dangling"), "dir");
+  }
+});
+
+afterAll(() => {
+  for (const d of [root, target, dataRoot]) {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("discoverVaults", () => {
+  it("discovers a real directory and skips dotfiles and regular files", () => {
+    const names = Object.keys(loadVaults());
+    expect(names).toContain("realvault");
+    expect(names).not.toContain(".hidden");
+    expect(names).not.toContain("notavault.md");
+  });
+
+  it.skipIf(!canSymlink)("discovers a symlinked directory as a vault", () => {
+    expect(Object.keys(loadVaults())).toContain("linkvault");
+  });
+
+  it.skipIf(!canSymlink)("skips a dangling symlink", () => {
+    expect(Object.keys(loadVaults())).not.toContain("dangling");
+  });
+});

--- a/apps/ignis-server/server/routes/bootstrap.js
+++ b/apps/ignis-server/server/routes/bootstrap.js
@@ -15,7 +15,8 @@ const {
 } = require("../plugin-system/manager");
 const { getVersion } = require("../version");
 const settings = require("../settings");
-const { sanitizeError } = require("@ignis/server-core");
+const { sanitizeError, writeCoalescer } = require("@ignis/server-core");
+const { getPending } = writeCoalescer;
 
 const router = express.Router();
 
@@ -61,14 +62,30 @@ async function walkTree(rootPath) {
         await walk(full, rel);
       } else {
         try {
-          const s = await fsp.stat(full);
+          const buffered = getPending(full);
 
-          tree[rel] = {
-            type: "file",
-            size: s.size,
-            mtime: s.mtimeMs,
-            ctime: s.ctimeMs,
-          };
+          if (buffered) {
+            const s = await fsp.stat(full).catch(() => null);
+            const size = Buffer.isBuffer(buffered.data)
+              ? buffered.data.length
+              : Buffer.byteLength(buffered.data, buffered.encoding || "utf-8");
+
+            tree[rel] = {
+              type: "file",
+              size,
+              mtime: Date.now(),
+              ctime: s ? s.ctimeMs : Date.now(),
+            };
+          } else {
+            const s = await fsp.stat(full);
+
+            tree[rel] = {
+              type: "file",
+              size: s.size,
+              mtime: s.mtimeMs,
+              ctime: s.ctimeMs,
+            };
+          }
         } catch {
           tree[rel] = { type: "file" };
         }
@@ -265,3 +282,4 @@ module.exports = router;
 module.exports.invalidateVault = invalidateVault;
 module.exports.invalidateAll = invalidateAll;
 module.exports.warmUp = warmUp;
+module.exports.walkTree = walkTree;

--- a/apps/ignis-server/server/routes/fs.js
+++ b/apps/ignis-server/server/routes/fs.js
@@ -9,7 +9,14 @@ const {
   resolveVaultPath,
   sanitizeError,
 } = require("@ignis/server-core");
-const { writeCoalesced, getPending } = writeCoalescer;
+const {
+  writeCoalesced,
+  getPending,
+  cancelPending,
+  flushPending,
+  cancelPendingSubtree,
+  flushPendingSubtree,
+} = writeCoalescer;
 const bootstrapRoutes = require("./bootstrap");
 
 const router = express.Router();
@@ -97,9 +104,7 @@ router.get("/stat", async (req, res) => {
       ctime: stat.ctimeMs,
     });
   } catch (e) {
-    res
-      .status(e.code === "ENOENT" ? 404 : 500)
-      .json(sanitizeError(e));
+    res.status(e.code === "ENOENT" ? 404 : 500).json(sanitizeError(e));
   }
 });
 
@@ -132,9 +137,7 @@ router.get("/readdir", async (req, res) => {
       })),
     );
   } catch (e) {
-    res
-      .status(e.code === "ENOENT" ? 404 : 500)
-      .json(sanitizeError(e));
+    res.status(e.code === "ENOENT" ? 404 : 500).json(sanitizeError(e));
   }
 });
 
@@ -183,9 +186,7 @@ router.get("/readFile", async (req, res) => {
       res.type("application/octet-stream").send(data);
     }
   } catch (e) {
-    res
-      .status(e.code === "ENOENT" ? 404 : 500)
-      .json(sanitizeError(e));
+    res.status(e.code === "ENOENT" ? 404 : 500).json(sanitizeError(e));
   }
 });
 
@@ -227,6 +228,7 @@ router.post("/appendFile", async (req, res) => {
   }
 
   try {
+    await flushPending(resolved);
     await fs.promises.appendFile(resolved, req.body.content, "utf-8");
 
     invalidateBootstrap(req);
@@ -248,6 +250,7 @@ router.post("/mkdir", async (req, res) => {
     await fs.promises.mkdir(resolved, {
       recursive: !!req.body.recursive,
     });
+    cancelPending(resolved);
 
     invalidateBootstrap(req);
     res.json({ ok: true });
@@ -276,7 +279,10 @@ router.post("/rename", async (req, res) => {
   }
 
   try {
+    await flushPending(oldResolved);
     await fs.promises.rename(oldResolved, newResolved);
+    // Drop the destination's buffer so a stale write cannot land on the renamed file.
+    cancelPending(newResolved);
 
     invalidateBootstrap(req);
     res.json({ ok: true });
@@ -305,7 +311,9 @@ router.post("/copyFile", async (req, res) => {
   }
 
   try {
+    await flushPending(srcResolved);
     await fs.promises.copyFile(srcResolved, destResolved);
+    cancelPending(destResolved);
 
     invalidateBootstrap(req);
     res.json({ ok: true });
@@ -324,12 +332,14 @@ router.delete("/unlink", async (req, res) => {
 
   try {
     await fs.promises.unlink(resolved);
+    cancelPending(resolved);
 
     invalidateBootstrap(req);
     res.json({ ok: true });
   } catch (e) {
     if (e.code === "ENOENT") {
-      // File already gone  -  desired outcome achieved
+      // File already gone; drop any buffered write so the flush cannot re-create it.
+      cancelPending(resolved);
       res.json({ ok: true });
     } else {
       res.status(500).json(sanitizeError(e));
@@ -347,6 +357,7 @@ router.delete("/rmdir", async (req, res) => {
 
   try {
     await fs.promises.rmdir(resolved);
+    cancelPendingSubtree(resolved);
 
     invalidateBootstrap(req);
     res.json({ ok: true });
@@ -367,6 +378,11 @@ router.delete("/rm", async (req, res) => {
     await fs.promises.rm(resolved, {
       recursive: req.query.recursive === "true",
     });
+    cancelPending(resolved);
+
+    if (req.query.recursive === "true") {
+      cancelPendingSubtree(resolved);
+    }
 
     invalidateBootstrap(req);
     res.json({ ok: true });
@@ -387,9 +403,7 @@ router.get("/access", async (req, res) => {
 
     res.json({ ok: true });
   } catch (e) {
-    res
-      .status(e.code === "ENOENT" ? 404 : 500)
-      .json(sanitizeError(e));
+    res.status(e.code === "ENOENT" ? 404 : 500).json(sanitizeError(e));
   }
 });
 
@@ -505,14 +519,30 @@ router.get("/tree", async (req, res) => {
 
           await walk(full, rel);
         } else {
-          const stat = await fs.promises.stat(full);
+          const buffered = getPending(full);
 
-          tree[rel] = {
-            type: "file",
-            size: stat.size,
-            mtime: stat.mtimeMs,
-            ctime: stat.ctimeMs,
-          };
+          if (buffered) {
+            const stat = await fs.promises.stat(full).catch(() => null);
+            const size = Buffer.isBuffer(buffered.data)
+              ? buffered.data.length
+              : Buffer.byteLength(buffered.data, buffered.encoding || "utf-8");
+
+            tree[rel] = {
+              type: "file",
+              size,
+              mtime: Date.now(),
+              ctime: stat ? stat.ctimeMs : Date.now(),
+            };
+          } else {
+            const stat = await fs.promises.stat(full);
+
+            tree[rel] = {
+              type: "file",
+              size: stat.size,
+              mtime: stat.mtimeMs,
+              ctime: stat.ctimeMs,
+            };
+          }
         }
       }
     }
@@ -534,6 +564,22 @@ router.get("/download", async (req, res) => {
   }
 
   try {
+    const filename = path.basename(resolved);
+    const buffered = getPending(resolved);
+
+    if (buffered) {
+      const body = Buffer.isBuffer(buffered.data)
+        ? buffered.data
+        : Buffer.from(buffered.data, buffered.encoding || "utf-8");
+
+      res.setHeader(
+        "Content-Disposition",
+        encodeContentDispositionFilename(filename),
+      );
+      res.setHeader("Content-Type", "application/octet-stream");
+      return res.send(body);
+    }
+
     const stat = await fs.promises.stat(resolved);
 
     if (stat.isDirectory()) {
@@ -542,16 +588,13 @@ router.get("/download", async (req, res) => {
         .json({ error: "Use /download-zip for directories" });
     }
 
-    const filename = path.basename(resolved);
     res.setHeader(
       "Content-Disposition",
       encodeContentDispositionFilename(filename),
     );
     res.sendFile(resolved);
   } catch (e) {
-    res
-      .status(e.code === "ENOENT" ? 404 : 500)
-      .json(sanitizeError(e));
+    res.status(e.code === "ENOENT" ? 404 : 500).json(sanitizeError(e));
   }
 });
 
@@ -569,6 +612,9 @@ router.get("/download-zip", async (req, res) => {
     if (!stat.isDirectory()) {
       return res.status(400).json({ error: "Not a directory" });
     }
+
+    // Persist buffered writes under the directory so archiver reads current bytes from disk.
+    await flushPendingSubtree(resolved);
 
     const folderName = path.basename(resolved);
     res.setHeader("Content-Type", "application/zip");
@@ -590,9 +636,7 @@ router.get("/download-zip", async (req, res) => {
     );
     archive.finalize();
   } catch (e) {
-    res
-      .status(e.code === "ENOENT" ? 404 : 500)
-      .json(sanitizeError(e));
+    res.status(e.code === "ENOENT" ? 404 : 500).json(sanitizeError(e));
   }
 });
 

--- a/apps/ignis-server/server/routes/fs.routes.test.mjs
+++ b/apps/ignis-server/server/routes/fs.routes.test.mjs
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { createRequire } from "module";
+import path from "path";
+import fs from "fs";
+import os from "os";
+
+const require = createRequire(import.meta.url);
+
+// setup test vault
+const VAULT_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "fs-route-test-"));
+process.env.VAULT_ROOT = VAULT_ROOT;
+const VAULT_ID = "v";
+const vaultDir = path.join(VAULT_ROOT, VAULT_ID);
+fs.mkdirSync(vaultDir, { recursive: true });
+
+const config = require("../config");
+config.refreshVaults();
+const fsRouter = require("./fs");
+const bootstrap = require("./bootstrap");
+const { writeCoalescer } = require("@ignis/server-core");
+const express = require("express");
+
+// Window must exceed two sequential localhost round-trips so the second write to a path buffers.
+const WINDOW = 400;
+writeCoalescer.configure({ writeCoalesceMs: WINDOW });
+
+let server;
+let base;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/fs", fsRouter);
+
+  await new Promise((resolve) => {
+    server = app.listen(0, resolve);
+  });
+
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(() => {
+  if (server) {
+    server.close();
+  }
+
+  writeCoalescer._reset();
+  fs.rmSync(VAULT_ROOT, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  writeCoalescer._reset();
+
+  for (const entry of fs.readdirSync(vaultDir)) {
+    fs.rmSync(path.join(vaultDir, entry), { recursive: true, force: true });
+  }
+});
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const u = (p) => `${base}/api/fs/${p}`;
+const q = (p) => `vault=${VAULT_ID}&path=${encodeURIComponent(p)}`;
+const onDisk = (p) => fs.readFileSync(path.join(vaultDir, p), "utf-8");
+const exists = (p) => fs.existsSync(path.join(vaultDir, p));
+const abs = (p) => path.join(vaultDir, p);
+
+const postJson = (p, body) =>
+  fetch(u(p), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ vault: VAULT_ID, ...body }),
+  });
+
+const writeFile = (p, content) => postJson("writeFile", { path: p, content });
+const mkdir = (p) => postJson("mkdir", { path: p });
+const rename = (oldPath, newPath) => postJson("rename", { oldPath, newPath });
+const copyFile = (src, dest) => postJson("copyFile", { src, dest });
+const appendFile = (p, content) => postJson("appendFile", { path: p, content });
+const unlink = (p) => fetch(u(`unlink?${q(p)}`), { method: "DELETE" });
+const rmdir = (p) => fetch(u(`rmdir?${q(p)}`), { method: "DELETE" });
+
+// Seed a buffered write: first write hits disk, second is held in the coalescer buffer.
+async function bufferWrite(p, first, second) {
+  await writeFile(p, first);
+  await writeFile(p, second);
+  expect(writeCoalescer.getPending(abs(p))).not.toBeNull();
+}
+
+describe("fs route handlers reconcile the coalescer buffer (WRITE_COALESCE_MS > 0)", () => {
+  it("unlink does not resurrect a deleted file", async () => {
+    await bufferWrite("x.md", "v1", "v2");
+
+    expect((await unlink("x.md")).ok).toBe(true);
+    await sleep(WINDOW + 200);
+
+    expect(exists("x.md")).toBe(false);
+  });
+
+  it("rename drops the destination buffer so it cannot clobber the renamed-in file", async () => {
+    await writeFile("a.md", "AAAA");
+    await bufferWrite("b.md", "b1", "b2b2");
+
+    expect((await rename("a.md", "b.md")).ok).toBe(true);
+    await sleep(WINDOW + 200);
+
+    expect(onDisk("b.md")).toBe("AAAA");
+    expect(exists("a.md")).toBe(false);
+  });
+
+  it("a failed rmdir keeps the buffered writes for files that survive", async () => {
+    await mkdir("d");
+    await bufferWrite("d/f.md", "v1", "v2new");
+
+    expect((await rmdir("d")).ok).toBe(false); // ENOTEMPTY
+    await sleep(WINDOW + 200);
+
+    expect(onDisk("d/f.md")).toBe("v2new");
+  });
+
+  it("copyFile copies the buffered source content, not stale disk", async () => {
+    await bufferWrite("s.md", "s1", "s2x");
+
+    expect((await copyFile("s.md", "dest.md")).ok).toBe(true);
+
+    expect(onDisk("dest.md")).toBe("s2x");
+  });
+
+  it("appendFile appends onto the buffered content without losing the append", async () => {
+    await bufferWrite("x.md", "base1", "base2");
+
+    expect((await appendFile("x.md", "APP")).ok).toBe(true);
+    await sleep(WINDOW + 200);
+
+    expect(onDisk("x.md")).toBe("base2APP");
+  });
+
+  it("download serves the buffered content, not stale disk", async () => {
+    await bufferWrite("x.md", "v1", "v2download");
+
+    const body = await (await fetch(u(`download?${q("x.md")}`))).text();
+
+    expect(body).toBe("v2download");
+  });
+
+  it("tree reports the buffered size, not stale disk", async () => {
+    await bufferWrite("x.md", "v1", "v2tree");
+
+    const tree = await (await fetch(u(`tree?vault=${VAULT_ID}`))).json();
+
+    expect(tree["x.md"].size).toBe(Buffer.byteLength("v2tree"));
+  });
+
+  it("download-zip flushes buffered writes so the archive holds current bytes", async () => {
+    await mkdir("d");
+    await bufferWrite("d/f.md", "v1", "v2zip");
+
+    await (await fetch(u(`download-zip?${q("d")}`))).arrayBuffer();
+
+    // flush-before-zip persists the buffer immediately, before the debounce window elapses.
+    expect(onDisk("d/f.md")).toBe("v2zip");
+    expect(writeCoalescer.getPending(abs("d/f.md"))).toBeNull();
+  });
+});
+
+describe("bootstrap walkTree", () => {
+  it("reports the buffered size for a pending coalesced write", async () => {
+    const p = abs("x.md");
+
+    await writeCoalescer.writeCoalesced(p, "v1", "utf-8");
+    await writeCoalescer.writeCoalesced(p, "v2bootstrap", "utf-8");
+    expect(writeCoalescer.getPending(p)).not.toBeNull();
+
+    const { tree } = await bootstrap.walkTree(vaultDir);
+
+    expect(tree["x.md"].size).toBe(Buffer.byteLength("v2bootstrap"));
+  });
+});

--- a/apps/ignis-server/server/routes/fs.test.mjs
+++ b/apps/ignis-server/server/routes/fs.test.mjs
@@ -1,5 +1,7 @@
 import path from "path";
-import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
@@ -105,5 +107,99 @@ describe("resolveVaultPath", () => {
 
   it("rejects traversal to a sibling vault with a shared prefix", () => {
     expect(resolveVaultPath(root, "../testing/foo")).toBe(null);
+  });
+
+  it("does not false-reject a vault based at the filesystem root", () => {
+    const fsRoot = path.parse(process.cwd()).root;
+    expect(resolveVaultPath(fsRoot, "child/leaf.md")).toBe(
+      path.resolve(fsRoot, "child/leaf.md"),
+    );
+  });
+});
+
+// -- resolveVaultPath symlink guard (filesystem) ---------------------
+
+// Symlink creation needs privilege or Developer Mode on Windows; skip those cases where it fails.
+let canSymlink = false;
+try {
+  const probe = fs.mkdtempSync(path.join(os.tmpdir(), "ignis-symlink-probe-"));
+  fs.symlinkSync(probe, path.join(probe, "l"), "dir");
+  canSymlink = true;
+  fs.rmSync(probe, { recursive: true, force: true });
+} catch {
+  canSymlink = false;
+}
+
+describe("resolveVaultPath symlink guard", () => {
+  let vault;
+  let outside;
+
+  beforeAll(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "ignis-vault-"));
+    outside = fs.mkdtempSync(path.join(os.tmpdir(), "ignis-outside-"));
+    fs.mkdirSync(path.join(vault, "notes"));
+    fs.writeFileSync(path.join(vault, "notes", "a.md"), "a");
+    fs.writeFileSync(path.join(outside, "secret.txt"), "s");
+
+    if (canSymlink) {
+      fs.symlinkSync(
+        path.join(outside, "secret.txt"),
+        path.join(vault, "escape"),
+        "file",
+      );
+      fs.symlinkSync(outside, path.join(vault, "escapedir"), "dir");
+      fs.symlinkSync(path.join(vault, "notes"), path.join(vault, "notelink"), "dir");
+      fs.symlinkSync(
+        path.join(outside, "newfile.txt"),
+        path.join(vault, "dangleout"),
+        "file",
+      );
+    }
+  });
+
+  afterAll(() => {
+    for (const d of [vault, outside]) {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a normal path inside the vault", () => {
+    expect(resolveVaultPath(vault, "notes/a.md")).toBe(
+      path.join(vault, "notes", "a.md"),
+    );
+  });
+
+  it("allows creating a new file inside the vault", () => {
+    expect(resolveVaultPath(vault, "notes/new.md")).toBe(
+      path.join(vault, "notes", "new.md"),
+    );
+  });
+
+  it.skipIf(!canSymlink)(
+    "rejects a symlink pointing to a file outside the vault",
+    () => {
+      expect(resolveVaultPath(vault, "escape")).toBe(null);
+    },
+  );
+
+  it.skipIf(!canSymlink)(
+    "rejects a directory symlink pointing outside the vault",
+    () => {
+      expect(resolveVaultPath(vault, "escapedir")).toBe(null);
+      expect(resolveVaultPath(vault, "escapedir/secret.txt")).toBe(null);
+    },
+  );
+
+  it.skipIf(!canSymlink)(
+    "rejects a dangling symlink pointing outside the vault",
+    () => {
+      expect(resolveVaultPath(vault, "dangleout")).toBe(null);
+    },
+  );
+
+  it.skipIf(!canSymlink)("allows an intra-vault symlink", () => {
+    expect(resolveVaultPath(vault, "notelink/a.md")).toBe(
+      path.join(vault, "notelink", "a.md"),
+    );
   });
 });

--- a/apps/ignis-server/server/routes/proxy.js
+++ b/apps/ignis-server/server/routes/proxy.js
@@ -205,18 +205,44 @@ function sameOrigin(a, b) {
   return a.protocol === b.protocol && a.host === b.host;
 }
 
+// Let the proxy handle the Content-Length and Transfer-Encoding headers itself.
+function stripRequestFramingHeaders(headers) {
+  const out = {};
+
+  for (const [key, val] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+
+    if (lower === "content-length" || lower === "transfer-encoding") {
+      continue;
+    }
+
+    out[key] = val;
+  }
+
+  return out;
+}
+
 function requestOnce(targetUrl, method, headers, body) {
   return new Promise((resolve, reject) => {
     const mod = targetUrl.protocol === "https:" ? https : http;
+    const outHeaders = stripRequestFramingHeaders(headers);
+    const hasBody = body != null && method !== "GET" && method !== "HEAD";
+
+    if (hasBody) {
+      // Set Content-Length from the exact bytes written.
+      // Avoids rejection from upstreams that do not accept chunked uploads.
+      outHeaders["Content-Length"] = Buffer.byteLength(body);
+    }
+
     const req = mod.request(
       targetUrl,
-      { method, headers, lookup: safeLookup },
+      { method, headers: outHeaders, lookup: safeLookup },
       resolve,
     );
 
     req.on("error", reject);
 
-    if (body && method !== "GET" && method !== "HEAD") {
+    if (hasBody) {
       req.write(body);
     }
 
@@ -428,5 +454,7 @@ router.post("/", async (req, res) => {
 module.exports = router;
 module.exports.isPrivateIp = isPrivateIp;
 module.exports.proxyRequest = proxyRequest;
+module.exports.requestOnce = requestOnce;
+module.exports.stripRequestFramingHeaders = stripRequestFramingHeaders;
 module.exports.buildAllowList = buildAllowList;
 module.exports.allowsAddress = allowsAddress;

--- a/apps/ignis-server/server/routes/proxy.test.mjs
+++ b/apps/ignis-server/server/routes/proxy.test.mjs
@@ -1,9 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { createRequire } from "module";
+import http from "node:http";
 
 const require = createRequire(import.meta.url);
-const { isPrivateIp, proxyRequest, buildAllowList, allowsAddress } =
-  require("./proxy.js");
+const {
+  isPrivateIp,
+  proxyRequest,
+  requestOnce,
+  stripRequestFramingHeaders,
+  buildAllowList,
+  allowsAddress,
+} = require("./proxy.js");
 
 describe("isPrivateIp", () => {
   it("flags private and link-local IPv4", () => {
@@ -94,5 +101,119 @@ describe("proxy private-host allow list", () => {
     expect(allow.exact.size).toBe(0);
     expect(allow.cidrV4.length).toBe(0);
     expect(allowsAddress(allow, "fd00::1")).toBe(false);
+  });
+});
+
+describe("stripRequestFramingHeaders", () => {
+  it("drops content-length and transfer-encoding case-insensitively", () => {
+    const out = stripRequestFramingHeaders({
+      "Content-Length": "5",
+      "transfer-encoding": "chunked",
+      "Content-Type": "text/plain",
+      Authorization: "Bearer x",
+    });
+
+    expect(out).toEqual({
+      "Content-Type": "text/plain",
+      Authorization: "Bearer x",
+    });
+  });
+
+  it("leaves headers untouched when no framing headers are present", () => {
+    const headers = { "Content-Type": "application/json", "X-Custom": "1" };
+
+    expect(stripRequestFramingHeaders(headers)).toEqual(headers);
+  });
+});
+
+describe("requestOnce framing", () => {
+  function startEcho() {
+    return new Promise((resolve) => {
+      const srv = http.createServer((req, res) => {
+        const chunks = [];
+        req.on("data", (c) => chunks.push(c));
+        req.on("end", () => {
+          const buf = Buffer.concat(chunks);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              declaredCL: req.headers["content-length"] ?? null,
+              transferEncoding: req.headers["transfer-encoding"] ?? null,
+              authorization: req.headers["authorization"] ?? null,
+              bytesRead: buf.length,
+              body: buf.toString("utf8"),
+            }),
+          );
+        });
+      });
+
+      srv.listen(0, "127.0.0.1", () => resolve(srv));
+    });
+  }
+
+  function readJson(res) {
+    return new Promise((resolve, reject) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString()));
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  }
+
+  it("writes the whole body despite a too-short caller Content-Length", async () => {
+    const srv = await startEcho();
+
+    try {
+      const { port } = srv.address();
+      const url = new URL(`http://127.0.0.1:${port}/`);
+      const body = "héllo wörld \u{1F600}"; // 18 utf8 bytes, 14 string chars
+
+      const res = await requestOnce(
+        url,
+        "PUT",
+        { "Content-Length": String(body.length), "X-Keep": "1" },
+        body,
+      );
+
+      const echoed = await readJson(res);
+
+      expect(echoed.bytesRead).toBe(Buffer.byteLength(body, "utf8"));
+      expect(echoed.body).toBe(body);
+      expect(Number(echoed.declaredCL)).toBe(Buffer.byteLength(body, "utf8"));
+      expect(echoed.transferEncoding).toBe(null);
+    } finally {
+      srv.close();
+    }
+  });
+
+  it("preserves non-framing headers while replacing Content-Length", async () => {
+    const srv = await startEcho();
+
+    try {
+      const { port } = srv.address();
+      const url = new URL(`http://127.0.0.1:${port}/`);
+      const body = Buffer.from([1, 2, 3, 4, 5, 6, 7]);
+
+      const res = await requestOnce(
+        url,
+        "PUT",
+        { "Content-Length": "999", Authorization: "Bearer tok" },
+        body,
+      );
+
+      const echoed = await readJson(res);
+
+      expect(echoed.bytesRead).toBe(body.length);
+      expect(Number(echoed.declaredCL)).toBe(body.length);
+      expect(echoed.transferEncoding).toBe(null);
+      expect(echoed.authorization).toBe("Bearer tok");
+    } finally {
+      srv.close();
+    }
   });
 });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,6 +83,8 @@ Reads not satisfied by ContentCache go through the transport layer to `/api/fs/r
 
 Writes go through a server-side write coalescer (`packages/server-core/src/write-coalescer.js`) designed for slow filesystems like rclone FUSE mounts. The first write to a path goes to disk immediately. Subsequent writes within a configurable window (`WRITE_COALESCE_MS`, default `0` which disables coalescing) are buffered and flushed when the debounce timer fires; the timer resets on each write. Buffered writes return to the HTTP client immediately with synthetic metadata so connection-pool starvation on rapid-fire writes (e.g. `workspace.json` autosaves) doesn't stall unrelated reads. Reads for pending paths serve the buffered content so clients never see stale data. All pending writes are flushed on graceful shutdown.
 
+A write that fails at the transport is queued per path and retried in the background with backoff, so a transient network or server error does not lose the write. A dirty-state store tracks which paths have writes still pending and which have exhausted their retries and failed. This state is exposed to other client components.
+
 ### Transforms
 
 The shim has a transforms registry (`packages/shim/src/fs/transforms.js`) for hooks applied at the public shim surface, before caches or transport see the path. Three hook types:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ignis-monorepo",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ignis-monorepo",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "workspaces": [
         "packages/*",
         "apps/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignis-monorepo",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "private": true,
   "description": "Monorepo for Ignis: a browser-based Obsidian client. Self-hosted server in apps/ignis-server; shim, UI, and shared libraries in packages/.",
   "workspaces": [

--- a/packages/bridge/src/main.js
+++ b/packages/bridge/src/main.js
@@ -25,7 +25,7 @@ class IgnisBridgePlugin extends Plugin {
     await pluginRegistry.refresh();
     patchSettingsModal(this);
     startDemoGuards();
-    this._statusBarInterval = initStatusBar(this);
+    this._statusBarUnsub = initStatusBar(this);
 
     this.addRibbonIcon("upload", "Upload file", () => {
       showFilePicker(this.app);
@@ -55,8 +55,8 @@ class IgnisBridgePlugin extends Plugin {
       return;
     }
 
-    if (this._statusBarInterval) {
-      clearInterval(this._statusBarInterval);
+    if (this._statusBarUnsub) {
+      this._statusBarUnsub();
     }
 
     unpatchSettingsModal(this);

--- a/packages/bridge/src/status-bar.js
+++ b/packages/bridge/src/status-bar.js
@@ -1,7 +1,9 @@
+import { Notice } from "obsidian";
+
 const STATUS_LABELS = {
-  open: "Ignis server: Connected",
-  connecting: "Ignis server: Connecting...",
-  closed: "Ignis server: Disconnected",
+  open: "Connected",
+  connecting: "Connecting...",
+  closed: "Disconnected",
 };
 
 const STATUS_DOT_CLASSES = {
@@ -10,26 +12,128 @@ const STATUS_DOT_CLASSES = {
   closed: "ignis-statusbar-disconnected",
 };
 
+// One status-bar item shows connection (dot color) and write state.
+// The dot pulses while writes lag or retry; a permanent give-up raises a Notice offering retry or reload.
 function initStatusBar(plugin) {
   const ws = window.__ignis.ws;
+  const writes = window.__ignis.writes;
 
   const item = plugin.addStatusBarItem();
   item.addClass("ignis-statusbar-item");
 
-  const dot = item.createEl("span", {
-    cls: "ignis-statusbar-dot",
-  });
+  const dot = item.createEl("span", { cls: "ignis-statusbar-dot" });
 
   item.setAttribute("data-tooltip-position", "top");
 
-  function render(state) {
-    dot.className = `ignis-statusbar-dot ${STATUS_DOT_CLASSES[state] || STATUS_DOT_CLASSES.closed}`;
-    item.setAttribute("aria-label", STATUS_LABELS[state] || STATUS_LABELS.closed);
+  let connState = ws.isOpen() ? "open" : "closed";
+  let writeState = writes ? writes.getState() : "clean";
+  let failureNotice = null;
+
+  function render() {
+    const pending = writeState === "pending";
+    const connClass =
+      STATUS_DOT_CLASSES[connState] || STATUS_DOT_CLASSES.closed;
+
+    dot.className = `ignis-statusbar-dot ${connClass}${pending ? " ignis-statusbar-writes-pending" : ""}`;
+
+    let label = `Server: ${STATUS_LABELS[connState] || STATUS_LABELS.closed}`;
+
+    if (pending && writes) {
+      const { retrying } = writes.getDetail();
+
+      label +=
+        retrying > 0 ? ` · Writes: ${retrying} retrying` : " · Writes: pending";
+    }
+
+    item.setAttribute("aria-label", label);
   }
 
-  render(ws.isOpen() ? "open" : "closed");
+  // A give-up replaces any prior Notice so the count stays current instead of stacking one per write.
+  function showFailureNotice() {
+    const count = writes.listFailed().length;
 
-  return ws.onStateChange(render);
+    if (count === 0) {
+      return;
+    }
+
+    if (failureNotice) {
+      failureNotice.hide();
+    }
+
+    const frag = document.createDocumentFragment();
+
+    const text = document.createElement("div");
+    text.textContent = `Ignis: ${count} change${count === 1 ? "" : "s"} could not be saved after repeated retries.`;
+    frag.appendChild(text);
+
+    const actions = document.createElement("div");
+    actions.className = "ignis-write-failure-actions";
+
+    const retry = document.createElement("button");
+    retry.textContent = "Retry";
+    retry.addEventListener("click", () => {
+      writes.retryAll();
+
+      if (failureNotice) {
+        failureNotice.hide();
+      }
+    });
+
+    const reload = document.createElement("button");
+    reload.textContent = "Reload";
+    reload.addEventListener("click", () => window.location.reload());
+
+    actions.appendChild(retry);
+    actions.appendChild(reload);
+    frag.appendChild(actions);
+
+    // Timeout 0 keeps the prompt until the user acts on it.
+    failureNotice = new Notice(frag, 0);
+  }
+
+  // Once a superseded failure leaves nothing failed, drop the prompt.
+  function reconcileFailureNotice() {
+    if (failureNotice && writes.listFailed().length === 0) {
+      failureNotice.hide();
+      failureNotice = null;
+    }
+  }
+
+  render();
+
+  //Refresh on hover so the tooltip reads the live count.
+  item.addEventListener("mouseenter", render);
+
+  const unsubConn = ws.onStateChange((state) => {
+    connState = state;
+    render();
+  });
+
+  let unsubWriteState = () => {};
+  let unsubFailure = () => {};
+  let unsubFailureChange = () => {};
+
+  if (writes) {
+    unsubWriteState = writes.onStateChange((state) => {
+      writeState = state;
+      render();
+    });
+
+    unsubFailure = writes.onFailure(() => showFailureNotice());
+    unsubFailureChange = writes.onFailureChange(() => reconcileFailureNotice());
+  }
+
+  return () => {
+    unsubConn();
+    unsubWriteState();
+    unsubFailure();
+    unsubFailureChange();
+
+    if (failureNotice) {
+      failureNotice.hide();
+      failureNotice = null;
+    }
+  };
 }
 
 export { initStatusBar };

--- a/packages/bridge/styles.css
+++ b/packages/bridge/styles.css
@@ -135,6 +135,27 @@
   background-color: var(--color-red);
 }
 
+.ignis-statusbar-writes-pending {
+  animation: ignis-writes-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes ignis-writes-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.ignis-write-failure-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
 .ignis-plugins-description {
   padding: 0 16px;
   color: var(--text-muted);

--- a/packages/server-core/src/path-utils.js
+++ b/packages/server-core/src/path-utils.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const fs = require("fs");
 
 /**
  * Encode a filename for use in Content-Disposition header.
@@ -49,6 +50,78 @@ function encodeContentDispositionFilename(filename) {
   return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`;
 }
 
+// Real path of a target that may not exist yet: resolves symlinks (including dangling ones) and keeps a not-yet-existing tail so creates resolve.
+// Returns null on error, so the caller fails closed.
+function canonicalize(target, depth = 0) {
+  if (depth > 40) {
+    return null;
+  }
+
+  let current = target;
+  const tail = [];
+
+  // Walk up to the deepest existing entry.
+  while (true) {
+    try {
+      fs.lstatSync(current);
+      break;
+    } catch (e) {
+      if (e.code !== "ENOENT") {
+        return null;
+      }
+
+      const parent = path.dirname(current);
+
+      if (parent === current) {
+        return null;
+      }
+
+      tail.push(path.basename(current));
+      current = parent;
+    }
+  }
+
+  let real;
+
+  try {
+    real = fs.realpathSync(current);
+  } catch (e) {
+    if (e.code !== "ENOENT") {
+      return null;
+    }
+
+    // realpath failed on an existing entry: a dangling symlink. Follow its target so confinement sees where a write lands.
+    let linkTarget;
+
+    try {
+      linkTarget = fs.readlinkSync(current);
+    } catch {
+      return null;
+    }
+
+    real = canonicalize(
+      path.resolve(path.dirname(current), linkTarget),
+      depth + 1,
+    );
+
+    if (real === null) {
+      return null;
+    }
+  }
+
+  return tail.length ? path.join(real, ...tail.reverse()) : real;
+}
+
+// A filesystem root already ends in the separator, so reuse a base that already ends in one.
+function isWithin(child, base) {
+  if (child === base) {
+    return true;
+  }
+
+  const prefix = base.endsWith(path.sep) ? base : base + path.sep;
+  return child.startsWith(prefix);
+}
+
 // Resolve a client-provided path to an absolute path within a vault.
 // Strips leading slashes so paths from the client are always treated as relative to the vault root.
 // Rejects nullish input so missing-field bugs in callers don't silently target the vault root.
@@ -58,16 +131,27 @@ function resolveVaultPath(vaultRoot, relativePath) {
   }
 
   const cleaned = relativePath.replace(/^\/+/, "");
-  const resolved = path.resolve(vaultRoot, cleaned);
-
   const resolvedRoot = path.resolve(vaultRoot);
+  const resolved = path.resolve(resolvedRoot, cleaned);
 
-  if (
-    resolved !== resolvedRoot &&
-    !resolved.startsWith(resolvedRoot + path.sep)
-  ) {
+  // Lexical guard: reject an obvious ../ escape before touching the filesystem.
+  if (!isWithin(resolved, resolvedRoot)) {
     return null;
   }
+
+  // Symlink guard: an in-vault symlink passes the lexical check but the OS follows it.
+  // Confine the target's realpath within the vault's realpath base (per-vault, since the base may itself be a symlink).
+  const realBase = canonicalize(resolvedRoot);
+  const realTarget = canonicalize(resolved);
+
+  if (realBase === null || realTarget === null) {
+    return null;
+  }
+
+  if (!isWithin(realTarget, realBase)) {
+    return null;
+  }
+
   return resolved;
 }
 

--- a/packages/server-core/src/write-coalescer.js
+++ b/packages/server-core/src/write-coalescer.js
@@ -5,6 +5,7 @@
 // Buffered writes respond to the HTTP client right away with synthetic mtime/size. Otherwise the browser's per-host connection cap blocks unrelated reads while writes sit in the buffer.
 
 const fs = require("fs");
+const path = require("path");
 
 const FLUSH_TIMEOUT_MS = 10000;
 
@@ -55,9 +56,16 @@ function flushEntry(absPath) {
 
   clearTimeout(entry.timer);
   pending.delete(absPath);
+  const { data, encoding } = entry;
 
-  writeToDisk(absPath, entry.data, entry.encoding).catch((err) => {
+  writeToDisk(absPath, data, encoding).catch((err) => {
     console.error(`[write-coalesce] Flush failed for ${absPath}:`, err);
+
+    // Re-buffer the failed write so a later flush retries it, unless a newer write already took the slot.
+    if (!pending.has(absPath)) {
+      pending.set(absPath, { data, encoding, timer: null });
+      scheduleFlush(absPath);
+    }
   });
 }
 
@@ -131,6 +139,75 @@ function getPending(absPath) {
   return null;
 }
 
+function cancelPending(absPath) {
+  const entry = pending.get(absPath);
+
+  if (!entry) {
+    return false;
+  }
+
+  clearTimeout(entry.timer);
+  pending.delete(absPath);
+  return true;
+}
+
+async function flushPending(absPath) {
+  const entry = pending.get(absPath);
+
+  if (!entry) {
+    return false;
+  }
+
+  clearTimeout(entry.timer);
+  pending.delete(absPath);
+  const { data, encoding } = entry;
+
+  try {
+    await writeToDisk(absPath, data, encoding);
+    return true;
+  } catch (e) {
+    // Re-buffer the failed write so a later flush retries it, unless a newer write already took the slot.
+    if (!pending.has(absPath)) {
+      pending.set(absPath, { data, encoding, timer: null });
+      scheduleFlush(absPath);
+    }
+
+    throw e;
+  }
+}
+
+function cancelPendingSubtree(absDir) {
+  const prefix = absDir.endsWith(path.sep) ? absDir : absDir + path.sep;
+  let dropped = 0;
+
+  for (const [absPath, entry] of pending) {
+    if (absPath === absDir || absPath.startsWith(prefix)) {
+      clearTimeout(entry.timer);
+      pending.delete(absPath);
+      dropped++;
+    }
+  }
+
+  return dropped;
+}
+
+async function flushPendingSubtree(absDir) {
+  const prefix = absDir.endsWith(path.sep) ? absDir : absDir + path.sep;
+  const targets = [];
+
+  for (const absPath of pending.keys()) {
+    if (absPath === absDir || absPath.startsWith(prefix)) {
+      targets.push(absPath);
+    }
+  }
+
+  for (const absPath of targets) {
+    await flushPending(absPath);
+  }
+
+  return targets.length;
+}
+
 /**
  * Flush all pending writes to disk. Called on graceful shutdown.
  */
@@ -175,4 +252,14 @@ function _reset() {
   lastWriteTime.clear();
 }
 
-module.exports = { writeCoalesced, getPending, flushAll, configure, _reset };
+module.exports = {
+  writeCoalesced,
+  getPending,
+  cancelPending,
+  flushPending,
+  cancelPendingSubtree,
+  flushPendingSubtree,
+  flushAll,
+  configure,
+  _reset,
+};

--- a/packages/server-core/src/write-coalescer.test.mjs
+++ b/packages/server-core/src/write-coalescer.test.mjs
@@ -147,3 +147,139 @@ describe("flushAll", () => {
     expect(coalescer.getPending(fileB)).toBeNull();
   });
 });
+
+describe("cancelPending", () => {
+  it("drops a buffered write so a deleted file does not resurrect", async () => {
+    const filePath = path.join(tmpDir, "file.txt");
+
+    await coalescer.writeCoalesced(filePath, "first", "utf-8");
+    await coalescer.writeCoalesced(filePath, "second", "utf-8");
+    await fs.promises.unlink(filePath);
+
+    expect(coalescer.cancelPending(filePath)).toBe(true);
+
+    await sleep(SHORT_WINDOW_MS + 30);
+
+    await expect(fs.promises.access(filePath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(coalescer.getPending(filePath)).toBeNull();
+  });
+
+  it("returns false when nothing is pending for the path", () => {
+    expect(coalescer.cancelPending(path.join(tmpDir, "absent.txt"))).toBe(false);
+  });
+});
+
+describe("flushPending", () => {
+  it("writes the latest buffered data to disk ahead of the debounce timer", async () => {
+    const filePath = path.join(tmpDir, "file.txt");
+
+    await coalescer.writeCoalesced(filePath, "first", "utf-8");
+    await coalescer.writeCoalesced(filePath, "second", "utf-8");
+
+    expect(await coalescer.flushPending(filePath)).toBe(true);
+    expect(await fs.promises.readFile(filePath, "utf-8")).toBe("second");
+    expect(coalescer.getPending(filePath)).toBeNull();
+  });
+
+  it("returns false when nothing is pending for the path", async () => {
+    expect(await coalescer.flushPending(path.join(tmpDir, "absent.txt"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("cancelPendingSubtree", () => {
+  it("drops buffered writes at or under a directory and leaves siblings and outsiders", async () => {
+    const dir = path.join(tmpDir, "sub");
+    const sibling = path.join(tmpDir, "subling");
+    await fs.promises.mkdir(dir);
+    await fs.promises.mkdir(sibling);
+
+    const inside = [path.join(dir, "a.txt"), path.join(dir, "b.txt")];
+    const outside = [path.join(tmpDir, "c.txt"), path.join(sibling, "d.txt")];
+
+    for (const f of [...inside, ...outside]) {
+      await coalescer.writeCoalesced(f, "first", "utf-8");
+      await coalescer.writeCoalesced(f, "buffered", "utf-8");
+    }
+
+    expect(coalescer.cancelPendingSubtree(dir)).toBe(2);
+
+    for (const f of inside) {
+      expect(coalescer.getPending(f)).toBeNull();
+    }
+
+    for (const f of outside) {
+      expect(coalescer.getPending(f)).not.toBeNull();
+    }
+  });
+});
+
+describe("flushPendingSubtree", () => {
+  it("flushes buffered writes at or under a directory to disk and clears them", async () => {
+    const dir = path.join(tmpDir, "sub");
+    await fs.promises.mkdir(dir);
+
+    const a = path.join(dir, "a.txt");
+    const b = path.join(dir, "b.txt");
+    const outside = path.join(tmpDir, "c.txt");
+
+    for (const f of [a, b, outside]) {
+      await coalescer.writeCoalesced(f, "first", "utf-8");
+      await coalescer.writeCoalesced(f, "buffered", "utf-8");
+    }
+
+    expect(await coalescer.flushPendingSubtree(dir)).toBe(2);
+
+    expect(await fs.promises.readFile(a, "utf-8")).toBe("buffered");
+    expect(await fs.promises.readFile(b, "utf-8")).toBe("buffered");
+    expect(coalescer.getPending(a)).toBeNull();
+    expect(coalescer.getPending(b)).toBeNull();
+    expect(coalescer.getPending(outside)).not.toBeNull();
+  });
+});
+
+describe("flush-failure durability", () => {
+  it("flushPending retains the buffer and retries when the disk write fails", async () => {
+    const filePath = path.join(tmpDir, "file.txt");
+
+    await coalescer.writeCoalesced(filePath, "first", "utf-8");
+    await coalescer.writeCoalesced(filePath, "second", "utf-8");
+
+    vi.spyOn(fs.promises, "writeFile").mockRejectedValueOnce(
+      Object.assign(new Error("EIO"), { code: "EIO" }),
+    );
+
+    await expect(coalescer.flushPending(filePath)).rejects.toThrow();
+
+    expect(coalescer.getPending(filePath)).not.toBeNull();
+    expect(coalescer.getPending(filePath).data).toBe("second");
+
+    await sleep(SHORT_WINDOW_MS + 50);
+
+    expect(await fs.promises.readFile(filePath, "utf-8")).toBe("second");
+    expect(coalescer.getPending(filePath)).toBeNull();
+  });
+
+  it("the debounce flush retains the buffer and retries when the disk write fails", async () => {
+    const filePath = path.join(tmpDir, "file.txt");
+
+    await coalescer.writeCoalesced(filePath, "first", "utf-8");
+    await coalescer.writeCoalesced(filePath, "second", "utf-8");
+
+    vi.spyOn(fs.promises, "writeFile").mockRejectedValueOnce(
+      Object.assign(new Error("EIO"), { code: "EIO" }),
+    );
+
+    await sleep(SHORT_WINDOW_MS + 50);
+
+    expect(coalescer.getPending(filePath)).not.toBeNull();
+
+    await sleep(SHORT_WINDOW_MS + 50);
+
+    expect(await fs.promises.readFile(filePath, "utf-8")).toBe("second");
+    expect(coalescer.getPending(filePath)).toBeNull();
+  });
+});

--- a/packages/shim/src/browser-detect.js
+++ b/packages/shim/src/browser-detect.js
@@ -1,0 +1,29 @@
+// Browser detection.
+
+// Edge, Opera, and Vivaldi user-agents also contain "Chrome", so they are matched before the Chrome default.
+export function detectBrowser(
+  ua = (typeof navigator !== "undefined" && navigator.userAgent) || "",
+) {
+  if (/\bEdg\//.test(ua)) {
+    return "edge";
+  }
+
+  if (/\bOPR\//.test(ua)) {
+    return "opera";
+  }
+
+  if (/\bVivaldi\//.test(ua)) {
+    return "vivaldi";
+  }
+
+  if (/\bFirefox\//.test(ua)) {
+    return "firefox";
+  }
+
+  // A genuine Safari carries "Safari" without "Chrome" or "Chromium"; Chrome's own user-agent includes "Safari".
+  if (/\bSafari\//.test(ua) && !/\bChrom(e|ium)\//.test(ua)) {
+    return "safari";
+  }
+
+  return "chrome";
+}

--- a/packages/shim/src/browser-detect.test.js
+++ b/packages/shim/src/browser-detect.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { detectBrowser } from "./browser-detect.js";
+
+const CHROME = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+const EDGE = CHROME + " Edg/124.0.0.0";
+const OPERA = CHROME + " OPR/109.0.0.0";
+const VIVALDI = CHROME + " Vivaldi/6.7";
+const FIREFOX = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:126.0) Gecko/20100101 Firefox/126.0";
+const SAFARI = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15";
+
+describe("detectBrowser", () => {
+  it("detects Chromium browsers, matching variants before the Chrome default (their UA also contains Chrome)", () => {
+    expect(detectBrowser(CHROME)).toBe("chrome");
+    expect(detectBrowser(EDGE)).toBe("edge");
+    expect(detectBrowser(OPERA)).toBe("opera");
+    expect(detectBrowser(VIVALDI)).toBe("vivaldi");
+  });
+
+  it("detects Firefox and Safari", () => {
+    expect(detectBrowser(FIREFOX)).toBe("firefox");
+    expect(detectBrowser(SAFARI)).toBe("safari");
+  });
+
+  it("defaults to Chrome for an unknown or empty user-agent", () => {
+    expect(detectBrowser("")).toBe("chrome");
+    expect(detectBrowser("something weird")).toBe("chrome");
+  });
+});

--- a/packages/shim/src/fs/content-cache.js
+++ b/packages/shim/src/fs/content-cache.js
@@ -78,6 +78,10 @@ export class ContentCache {
     return this._currentSize;
   }
 
+  get maxSize() {
+    return this._maxSize;
+  }
+
   _evictOne() {
     let oldest = null;
     let oldestTime = Infinity;

--- a/packages/shim/src/fs/content-cache.test.js
+++ b/packages/shim/src/fs/content-cache.test.js
@@ -90,3 +90,18 @@ describe("ContentCache path normalization", () => {
     expect(cache.get("foo/bar/baz.md")).toBe("content");
   });
 });
+
+// -- Configured capacity -----------------------------------------------
+
+describe("ContentCache maxSize", () => {
+  it("reports the size passed to the constructor", () => {
+    const cache = new ContentCache(7 * 1024);
+    expect(cache.maxSize).toBe(7 * 1024);
+  });
+
+  it("reflects a later setMaxSize", () => {
+    const cache = new ContentCache(1024);
+    cache.setMaxSize(64 * 1024);
+    expect(cache.maxSize).toBe(64 * 1024);
+  });
+});

--- a/packages/shim/src/fs/indexer-prefetch.js
+++ b/packages/shim/src/fs/indexer-prefetch.js
@@ -4,9 +4,22 @@
 // The bulk slice (everything else) streams afterward without blocking boot.
 
 const TEXT_EXTENSIONS = new Set([
-  ".md", ".markdown", ".txt", ".json", ".csv",
-  ".css", ".js", ".ts", ".tsx", ".mjs", ".cjs",
-  ".html", ".xml", ".yaml", ".yml", ".toml",
+  ".md",
+  ".markdown",
+  ".txt",
+  ".json",
+  ".csv",
+  ".css",
+  ".js",
+  ".ts",
+  ".tsx",
+  ".mjs",
+  ".cjs",
+  ".html",
+  ".xml",
+  ".yaml",
+  ".yml",
+  ".toml",
   ".svg",
 ]);
 
@@ -17,6 +30,8 @@ const PRIORITY_MAX_FILE_BYTES = 4 * 1024 * 1024; // 4 MB
 // Cap the priority slice's share of the total so a heavy config or plugin set cannot starve the bulk slice.
 const PRIORITY_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
 const BATCH_SIZE = 50;
+// Number of batch-reads in flight at once, capped to the browser's per-origin connection pool (about six on HTTP/1.1).
+const BATCH_CONCURRENCY = 6;
 
 function isTextPath(path) {
   const dot = path.lastIndexOf(".");
@@ -120,37 +135,58 @@ async function runBatches(vaultId, slice, contentCache, label, onProgress) {
     onProgress(0, slice.bytes);
   }
 
+  const batches = [];
+
   for (let i = 0; i < slice.files.length; i += BATCH_SIZE) {
-    const batch = slice.files.slice(i, i + BATCH_SIZE);
+    batches.push(slice.files.slice(i, i + BATCH_SIZE));
+  }
 
-    let result;
+  // Several workers pull batches off a shared cursor until all batches are processed or one fails.
+  let cursor = 0;
+  let aborted = false;
 
-    try {
-      result = await fetchBatch(
-        vaultId,
-        batch.map((f) => f.path),
-      );
-    } catch (e) {
-      // Abandon the rest of this slice; the returned promise still resolves so boot is never blocked on a failed batch.
-      console.warn(`[ignis] Prefetch ${label} batch failed:`, e.message);
-      return;
-    }
+  async function worker() {
+    while (!aborted) {
+      const idx = cursor++;
 
-    for (const [path, content] of Object.entries(result.files || {})) {
-      if (typeof content === "string") {
-        contentCache.set(path, content);
-        cached++;
-      }
-    }
-
-    if (onProgress) {
-      for (const f of batch) {
-        received += f.size;
+      if (idx >= batches.length) {
+        return;
       }
 
-      onProgress(received, slice.bytes);
+      const batch = batches[idx];
+
+      let result;
+
+      try {
+        result = await fetchBatch(
+          vaultId,
+          batch.map((f) => f.path),
+        );
+      } catch (e) {
+        console.warn(`[ignis] Prefetch ${label} batch failed:`, e.message);
+        aborted = true;
+        return;
+      }
+
+      for (const [path, content] of Object.entries(result.files || {})) {
+        if (typeof content === "string") {
+          contentCache.set(path, content);
+          cached++;
+        }
+      }
+
+      if (onProgress) {
+        for (const f of batch) {
+          received += f.size;
+        }
+
+        onProgress(received, slice.bytes);
+      }
     }
   }
+
+  const workerCount = Math.max(1, Math.min(BATCH_CONCURRENCY, batches.length));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
 
   const ms = Date.now() - t0;
 
@@ -161,7 +197,12 @@ async function runBatches(vaultId, slice, contentCache, label, onProgress) {
 
 // Returns { priority, bulk }: a promise for each slice.
 // The priority promise resolves once the boot-critical files have landed (or were abandoned on a batch failure), so it is always safe to await.
-export function prefetchVaultContent(vaultId, tree, contentCache, options = {}) {
+export function prefetchVaultContent(
+  vaultId,
+  tree,
+  contentCache,
+  options = {},
+) {
   if (!vaultId || !tree) {
     return { priority: Promise.resolve(), bulk: Promise.resolve() };
   }

--- a/packages/shim/src/fs/indexer-prefetch.js
+++ b/packages/shim/src/fs/indexer-prefetch.js
@@ -43,8 +43,7 @@ function isTextPath(path) {
   return TEXT_EXTENSIONS.has(path.slice(dot).toLowerCase());
 }
 
-// Boot-critical files: root-level .obsidian configs and each plugin's entry files.
-// Plugin data.json and other nested config fall to the bulk slice so a large blob does not inflate the awaited slice.
+// The core boot-critical files: root-level .obsidian configs and each plugin's entry files.
 function isPriorityPath(path) {
   if (!path.startsWith(".obsidian/")) {
     return false;
@@ -58,6 +57,10 @@ function isPriorityPath(path) {
   return /^\.obsidian\/plugins\/[^/]+\/(main\.js|manifest\.json|styles\.css)$/.test(
     path,
   );
+}
+
+function isDataJsonPath(path) {
+  return /^\.obsidian\/plugins\/[^/]+\/data\.json$/.test(path);
 }
 
 function collectSlice(entries, predicate, perFileCap, budget) {
@@ -89,17 +92,33 @@ function collectSlice(entries, predicate, perFileCap, budget) {
 function selectPrefetchTargets(tree) {
   // Tree key order matches directory traversal (the server walk emits parent before children).
   const entries = Object.entries(tree);
-  const priority = collectSlice(
+
+  // Admit the core boot files first, then each plugin's data.json into the leftover budget, so data.json never evicts a core file.
+  const core = collectSlice(
     entries,
     isPriorityPath,
     PRIORITY_MAX_FILE_BYTES,
     PRIORITY_MAX_BYTES,
   );
 
-  // Bulk fills whatever byte budget the priority slice left.
+  const data = collectSlice(
+    entries,
+    isDataJsonPath,
+    PRIORITY_MAX_FILE_BYTES,
+    PRIORITY_MAX_BYTES - core.bytes,
+  );
+
+  const priority = {
+    files: [...core.files, ...data.files],
+    bytes: core.bytes + data.bytes,
+  };
+
+  // Bulk is everything the priority slice did not admit, so a file dropped from priority by a cap or the budget still gets a chance in bulk.
+  const admitted = new Set(priority.files.map((f) => f.path));
+
   const bulk = collectSlice(
     entries,
-    (path) => !isPriorityPath(path),
+    (path) => !admitted.has(path),
     MAX_FILE_BYTES,
     MAX_BYTES - priority.bytes,
   );

--- a/packages/shim/src/fs/indexer-prefetch.js
+++ b/packages/shim/src/fs/indexer-prefetch.js
@@ -1,7 +1,5 @@
-// Batch pre-fetch of vault content into ContentCache.
-// Pulls text file contents in batches via /api/fs/batch-read and drops them into ContentCache so Obsidian's startup reads hit the cache instead of fetching each file individually.
-// The priority slice (.obsidian configs and plugin entry files) is fetched first and its promise resolves once it lands, so boot can wait for those reads to be warm.
-// The bulk slice (everything else) streams afterward without blocking boot.
+// Pre-fetches vault file contents into the content cache before Obsidian boots, so its startup reads hit the cache instead of the network.
+// The priority slice is awaited and gates boot; the bulk slice streams afterward without blocking it.
 
 const TEXT_EXTENSIONS = new Set([
   ".md",
@@ -23,15 +21,17 @@ const TEXT_EXTENSIONS = new Set([
   ".svg",
 ]);
 
-const MAX_BYTES = 30 * 1024 * 1024; // 30 MB total across both slices
-const MAX_FILE_BYTES = 512 * 1024; // skip bulk files larger than 512 KB
-// Plugin main.js bundles can run a few MB and Obsidian needs them at boot, so the priority slice accepts larger files than the bulk slice.
-const PRIORITY_MAX_FILE_BYTES = 4 * 1024 * 1024; // 4 MB
-// Cap the priority slice's share of the total so a heavy config or plugin set cannot starve the bulk slice.
-const PRIORITY_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_FILE_BYTES = 512 * 1024;
+// Plugin bundles run a few MB and Obsidian needs them at boot, so priority accepts larger files than bulk.
+const PRIORITY_MAX_FILE_BYTES = 4 * 1024 * 1024;
 const BATCH_SIZE = 50;
-// Number of batch-reads in flight at once, capped to the browser's per-origin connection pool (about six on HTTP/1.1).
-const BATCH_CONCURRENCY = 6;
+const BATCH_CONCURRENCY = 6; // concurrent in-flight batch-reads, to pipeline requests and hide round-trip latency
+// Cap a slice's file count so a vault or plugin with tens of thousands of small files cannot turn boot into one request per file.
+const MAX_FILES = 4000;
+const PREFETCH_CACHE_FRACTION = 0.75; // leave cache headroom so on-demand reads do not immediately evict prefetched content
+const PREFETCH_MAX_BYTES = 100 * 1024 * 1024; // ceiling on boot prefetch I/O regardless of cache size
+const PREFETCH_MIN_BYTES = 8 * 1024 * 1024; // floor; a cache below 8 MB is clamped to its own size instead
+const DEFAULT_CACHE_BYTES = 50 * 1024 * 1024;
 
 function isTextPath(path) {
   const dot = path.lastIndexOf(".");
@@ -43,13 +43,12 @@ function isTextPath(path) {
   return TEXT_EXTENSIONS.has(path.slice(dot).toLowerCase());
 }
 
-// The core boot-critical files: root-level .obsidian configs and each plugin's entry files.
+// Boot-critical files: root .obsidian configs and each plugin's entry files.
 function isPriorityPath(path) {
   if (!path.startsWith(".obsidian/")) {
     return false;
   }
 
-  // Root-level configs only (app.json, appearance.json, core-plugins.json, workspace.json, etc.).
   if (/^\.obsidian\/[^/]+\.json$/.test(path)) {
     return true;
   }
@@ -63,9 +62,36 @@ function isDataJsonPath(path) {
   return /^\.obsidian\/plugins\/[^/]+\/data\.json$/.test(path);
 }
 
-function collectSlice(entries, predicate, perFileCap, budget) {
+// Plugin-internal files (icon packs, fonts) are read on demand, never at boot, and a plugin can bundle tens of thousands, so bulk skips them.
+function isPluginAsset(path) {
+  return (
+    /^\.obsidian\/plugins\/[^/]+\//.test(path) &&
+    !isPriorityPath(path) &&
+    !isDataJsonPath(path)
+  );
+}
+
+// Scaled from the content cache and capped at the cache size itself, so the prefetch cannot evict its own content mid-fetch.
+function prefetchByteBudget(contentCache) {
+  const cacheMax =
+    contentCache && Number.isFinite(contentCache.maxSize)
+      ? contentCache.maxSize
+      : DEFAULT_CACHE_BYTES;
+
+  return Math.min(
+    PREFETCH_MAX_BYTES,
+    cacheMax,
+    Math.max(
+      PREFETCH_MIN_BYTES,
+      Math.floor(cacheMax * PREFETCH_CACHE_FRACTION),
+    ),
+  );
+}
+
+function collectSlice(entries, predicate, perFileCap, budget, label) {
   const files = [];
   let bytes = 0;
+  let truncated = 0;
 
   for (const [path, entry] of entries) {
     if (entry.type !== "file" || !isTextPath(path) || !predicate(path)) {
@@ -82,30 +108,44 @@ function collectSlice(entries, predicate, perFileCap, budget) {
       continue;
     }
 
+    if (files.length >= MAX_FILES) {
+      truncated++;
+      continue;
+    }
+
     files.push({ path, size });
     bytes += size;
+  }
+
+  if (truncated > 0) {
+    console.warn(
+      `[ignis] Prefetch ${label} slice hit the ${MAX_FILES}-file cap; ${truncated} file(s) left for on-demand reads.`,
+    );
   }
 
   return { files, bytes };
 }
 
-function selectPrefetchTargets(tree) {
+function selectPrefetchTargets(tree, totalBudget) {
   // Tree key order matches directory traversal (the server walk emits parent before children).
   const entries = Object.entries(tree);
 
-  // Admit the core boot files first, then each plugin's data.json into the leftover budget, so data.json never evicts a core file.
+  // Priority draws from the whole budget first since its files are read during boot; warming them up front beats reading them on demand.
+  // Admit the core boot files before each plugin's data.json so a large data.json cannot crowd out a core file.
   const core = collectSlice(
     entries,
     isPriorityPath,
     PRIORITY_MAX_FILE_BYTES,
-    PRIORITY_MAX_BYTES,
+    totalBudget,
+    "priority",
   );
 
   const data = collectSlice(
     entries,
     isDataJsonPath,
     PRIORITY_MAX_FILE_BYTES,
-    PRIORITY_MAX_BYTES - core.bytes,
+    totalBudget - core.bytes,
+    "data.json",
   );
 
   const priority = {
@@ -113,14 +153,14 @@ function selectPrefetchTargets(tree) {
     bytes: core.bytes + data.bytes,
   };
 
-  // Bulk is everything the priority slice did not admit, so a file dropped from priority by a cap or the budget still gets a chance in bulk.
   const admitted = new Set(priority.files.map((f) => f.path));
 
   const bulk = collectSlice(
     entries,
-    (path) => !admitted.has(path),
+    (path) => !admitted.has(path) && !isPluginAsset(path),
     MAX_FILE_BYTES,
-    MAX_BYTES - priority.bytes,
+    totalBudget - priority.bytes,
+    "bulk",
   );
 
   return { priority, bulk };
@@ -214,8 +254,7 @@ async function runBatches(vaultId, slice, contentCache, label, onProgress) {
   );
 }
 
-// Returns { priority, bulk }: a promise for each slice.
-// The priority promise resolves once the boot-critical files have landed (or were abandoned on a batch failure), so it is always safe to await.
+// The priority promise resolves once the boot-critical files land (or are abandoned on a batch failure), so it is always safe to await.
 export function prefetchVaultContent(
   vaultId,
   tree,
@@ -226,7 +265,8 @@ export function prefetchVaultContent(
     return { priority: Promise.resolve(), bulk: Promise.resolve() };
   }
 
-  const { priority, bulk } = selectPrefetchTargets(tree);
+  const totalBudget = prefetchByteBudget(contentCache);
+  const { priority, bulk } = selectPrefetchTargets(tree, totalBudget);
 
   const priorityDone = runBatches(
     vaultId,
@@ -236,8 +276,7 @@ export function prefetchVaultContent(
     options.onProgress,
   );
 
-  // Bulk streams after the priority slice so it does not contend for the connection pool while boot is waiting on priority.
-  // It runs regardless of how priority settled and swallows its own rejection, since init.js discards this promise.
+  // Bulk streams after priority so it does not contend for connections while boot waits on priority, and swallows its own rejection.
   const bulkDone = priorityDone
     .catch(() => {})
     .then(() => runBatches(vaultId, bulk, contentCache, "bulk"))

--- a/packages/shim/src/fs/indexer-prefetch.test.js
+++ b/packages/shim/src/fs/indexer-prefetch.test.js
@@ -145,3 +145,59 @@ describe("prefetchVaultContent slicing", () => {
     await expect(result.priority).resolves.toBeUndefined();
   });
 });
+
+describe("prefetchVaultContent parallel batching", () => {
+  it("fetches every file across multiple batches and caches each exactly once", async () => {
+    const many = {};
+
+    for (let i = 0; i < 120; i++) {
+      many[`Note${i}.md`] = { type: "file", size: 100 };
+    }
+
+    const cache = makeCache();
+    const result = prefetchVaultContent("v", many, cache);
+    await result.bulk;
+
+    // 120 files / 50 per batch = 3 batches; the worker pool fetches each path once and caches all.
+    expect(fetchCalls.length).toBe(3);
+
+    const allPaths = fetchCalls.flat();
+    expect(allPaths.length).toBe(120);
+    expect(new Set(allPaths).size).toBe(120);
+    expect(cache.store.size).toBe(120);
+  });
+
+  it("caches the batches that landed before a mid-stream failure, without rejecting", async () => {
+    const many = {};
+
+    for (let i = 0; i < 120; i++) {
+      many[`Note${i}.md`] = { type: "file", size: 100 };
+    }
+
+    let calls = 0;
+    globalThis.fetch = vi.fn(async (url, init) => {
+      calls++;
+
+      if (calls === 2) {
+        return { ok: false, status: 500 };
+      }
+
+      const paths = JSON.parse(init.body).paths;
+      const files = {};
+
+      for (const p of paths) {
+        files[p] = "content:" + p;
+      }
+
+      return { ok: true, json: async () => ({ files }) };
+    });
+
+    const cache = makeCache();
+    const result = prefetchVaultContent("v", many, cache);
+
+    await expect(result.bulk).resolves.toBeUndefined();
+    // The batches that landed before the failing one are cached; the failure abandons the rest.
+    expect(cache.store.size).toBeGreaterThan(0);
+    expect(cache.store.size).toBeLessThan(120);
+  });
+});

--- a/packages/shim/src/fs/indexer-prefetch.test.js
+++ b/packages/shim/src/fs/indexer-prefetch.test.js
@@ -88,8 +88,8 @@ describe("prefetchVaultContent slicing", () => {
     expect(fetchCalls[1]).not.toContain(".obsidian/plugins/big/data.json");
   });
 
-  it("admits core entry files before data.json, so a large data.json cannot evict a core file", async () => {
-    // The three 3 MB main.js fill 9 MB of the 10 MB priority budget, leaving no room for the 3 MB data.json.
+  it("admits core entry files before data.json, so a large data.json cannot crowd out a core file", async () => {
+    // A 12 MB cache yields a 9 MB budget; the three 3 MB main.js fill it, leaving no room for the 3 MB data.json.
     const t = {
       ".obsidian/plugins/a/main.js": { type: "file", size: 3 * MB },
       ".obsidian/plugins/b/main.js": { type: "file", size: 3 * MB },
@@ -97,7 +97,8 @@ describe("prefetchVaultContent slicing", () => {
       ".obsidian/plugins/a/data.json": { type: "file", size: 3 * MB },
     };
 
-    const result = prefetchVaultContent("v", t, makeCache());
+    const cache = { ...makeCache(), maxSize: 12 * MB };
+    const result = prefetchVaultContent("v", t, cache);
     await result.bulk;
 
     expect(fetchCalls[0]).toEqual(
@@ -110,18 +111,33 @@ describe("prefetchVaultContent slicing", () => {
     expect(fetchCalls[0]).not.toContain(".obsidian/plugins/a/data.json");
   });
 
-  it("caps the priority slice at its own byte budget", async () => {
-    // Three 4MB plugin entry files: two fit the 10MB priority budget, the third is dropped.
+  it("caps the priority slice at the cache-derived budget", async () => {
+    // A 12 MB cache yields a 9 MB budget; two 4 MB entry files fit, the third is dropped.
     const bigTree = {
       ".obsidian/plugins/a/main.js": { type: "file", size: 4 * MB },
       ".obsidian/plugins/b/main.js": { type: "file", size: 4 * MB },
       ".obsidian/plugins/c/main.js": { type: "file", size: 4 * MB },
     };
 
-    const result = prefetchVaultContent("v", bigTree, makeCache());
+    const cache = { ...makeCache(), maxSize: 12 * MB };
+    const result = prefetchVaultContent("v", bigTree, cache);
     await result.bulk;
 
     expect(fetchCalls[0].length).toBe(2);
+  });
+
+  it("warms all plugin bundles into priority when the cache budget allows", async () => {
+    // Six 3 MB plugin bundles is 18 MB of boot-critical files; the default ~37 MB budget admits them all.
+    const t = {};
+
+    for (const p of ["a", "b", "c", "d", "e", "f"]) {
+      t[".obsidian/plugins/" + p + "/main.js"] = { type: "file", size: 3 * MB };
+    }
+
+    const result = prefetchVaultContent("v", t, makeCache());
+    await result.bulk;
+
+    expect(fetchCalls[0].length).toBe(6);
   });
 
   it("drops a bulk file over the 512KB per-file cap", async () => {
@@ -181,7 +197,7 @@ describe("prefetchVaultContent parallel batching", () => {
     const result = prefetchVaultContent("v", many, cache);
     await result.bulk;
 
-    // 120 files / 50 per batch = 3 batches; the worker pool fetches each path once and caches all.
+    // 120 files / 50 per batch = 3 batches; each path is fetched once and cached.
     expect(fetchCalls.length).toBe(3);
 
     const allPaths = fetchCalls.flat();
@@ -222,5 +238,144 @@ describe("prefetchVaultContent parallel batching", () => {
     // The batches that landed before the failing one are cached; the failure abandons the rest.
     expect(cache.store.size).toBeGreaterThan(0);
     expect(cache.store.size).toBeLessThan(120);
+  });
+});
+
+describe("prefetchVaultContent plugin folder handling", () => {
+  it("does not prefetch plugin-internal asset files in either slice, but keeps data.json", async () => {
+    const t = {
+      ".obsidian/plugins/iconize/main.js": { type: "file", size: 100 },
+      ".obsidian/plugins/iconize/icons/pack/a.svg": { type: "file", size: 200 },
+      ".obsidian/plugins/iconize/icons/pack/b.svg": { type: "file", size: 200 },
+      ".obsidian/plugins/iconize/data.json": { type: "file", size: 50 },
+      "Note.md": { type: "file", size: 100 },
+    };
+
+    const result = prefetchVaultContent("v", t, makeCache());
+    await result.bulk;
+
+    const all = fetchCalls.flat();
+    expect(all).not.toContain(".obsidian/plugins/iconize/icons/pack/a.svg");
+    expect(all).not.toContain(".obsidian/plugins/iconize/icons/pack/b.svg");
+    expect(all).toContain(".obsidian/plugins/iconize/data.json");
+    expect(all).toContain("Note.md");
+  });
+
+  it("does not prefetch a plugin's bundled markdown", async () => {
+    const t = {
+      ".obsidian/plugins/p/templates/T.md": { type: "file", size: 100 },
+      "Real.md": { type: "file", size: 100 },
+    };
+
+    const result = prefetchVaultContent("v", t, makeCache());
+    await result.bulk;
+
+    const all = fetchCalls.flat();
+    expect(all).not.toContain(".obsidian/plugins/p/templates/T.md");
+    expect(all).toContain("Real.md");
+  });
+
+  it("excludes a nested data.json, admitting only a plugin's top-level data.json", async () => {
+    const t = {
+      ".obsidian/plugins/foo/data.json": { type: "file", size: 50 },
+      ".obsidian/plugins/foo/sub/data.json": { type: "file", size: 50 },
+      "Note.md": { type: "file", size: 100 },
+    };
+
+    const result = prefetchVaultContent("v", t, makeCache());
+    await result.bulk;
+
+    const all = fetchCalls.flat();
+    expect(all).toContain(".obsidian/plugins/foo/data.json");
+    expect(all).not.toContain(".obsidian/plugins/foo/sub/data.json");
+  });
+
+  it("prefetches snippets and themes in the bulk slice", async () => {
+    const t = {
+      ".obsidian/app.json": { type: "file", size: 100 },
+      ".obsidian/snippets/custom.css": { type: "file", size: 100 },
+      ".obsidian/themes/MyTheme/theme.css": { type: "file", size: 100 },
+    };
+
+    const result = prefetchVaultContent("v", t, makeCache());
+    await result.bulk;
+
+    const bulk = fetchCalls[1] || [];
+    expect(bulk).toContain(".obsidian/snippets/custom.css");
+    expect(bulk).toContain(".obsidian/themes/MyTheme/theme.css");
+  });
+});
+
+describe("prefetchVaultContent file and byte caps", () => {
+  it("caps the number of files prefetched at MAX_FILES and warns once", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const t = {};
+
+    for (let i = 0; i < 5000; i++) {
+      t["notes/n" + i + ".md"] = { type: "file", size: 10 };
+    }
+
+    const result = prefetchVaultContent("v", t, makeCache());
+    await result.bulk;
+
+    expect(fetchCalls.flat().length).toBe(4000);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("4000-file cap"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("1000 file(s)"),
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("shrinks the byte budget when the content cache is small", async () => {
+    const t = {};
+
+    // 40 notes of 0.4 MB each (under the 512 KB per-file cap) is 16 MB of candidates.
+    for (let i = 0; i < 40; i++) {
+      t["n" + i + ".md"] = { type: "file", size: 400 * 1024 };
+    }
+
+    // A 16 MB cache yields a 0.75 * 16 = 12 MB budget; 30 of the 40 notes (30 * 400 KB) fit, the 31st would exceed it.
+    const cache = { ...makeCache(), maxSize: 16 * MB };
+    const result = prefetchVaultContent("v", t, cache);
+    await result.bulk;
+
+    expect(fetchCalls.flat().length).toBe(30);
+  });
+
+  it("clamps the total budget to the cache size so the prefetch never exceeds it", async () => {
+    const t = {};
+
+    // 20 notes of 0.4 MB each is 8 MB of candidates; a 4 MB cache must hold the prefetch within 4 MB.
+    for (let i = 0; i < 20; i++) {
+      t["n" + i + ".md"] = { type: "file", size: 400 * 1024 };
+    }
+
+    // A 4 MB cache: the budget clamps to 4 MB even though the 8 MB floor is higher, so the prefetch cannot self-evict.
+    const cache = { ...makeCache(), maxSize: 4 * MB };
+    const result = prefetchVaultContent("v", t, cache);
+    await result.bulk;
+
+    expect(fetchCalls.flat().length).toBe(10);
+    expect(fetchCalls.flat().length * 400 * 1024).toBeLessThanOrEqual(4 * MB);
+  });
+
+  it("lets priority claim the whole budget ahead of bulk, leaving a note for on-demand", async () => {
+    const t = {
+      ".obsidian/plugins/a/main.js": { type: "file", size: 3 * MB },
+      ".obsidian/plugins/b/main.js": { type: "file", size: 3 * MB },
+      ".obsidian/plugins/c/main.js": { type: "file", size: 3 * MB },
+      "Note.md": { type: "file", size: 100 },
+    };
+
+    // A 12 MB cache yields a 9 MB budget; the three 3 MB bundles claim all of it, so the note is left for on-demand.
+    const cache = { ...makeCache(), maxSize: 12 * MB };
+    const result = prefetchVaultContent("v", t, cache);
+
+    await expect(result.bulk).resolves.toBeUndefined();
+    const all = fetchCalls.flat();
+    expect(all).toContain(".obsidian/plugins/a/main.js");
+    expect(all).not.toContain("Note.md");
   });
 });

--- a/packages/shim/src/fs/indexer-prefetch.test.js
+++ b/packages/shim/src/fs/indexer-prefetch.test.js
@@ -17,7 +17,8 @@ const tree = {
   somedir: { type: "directory" },
 };
 
-const PRIORITY_BYTES = 100 + 50 + 2 * MB + 80 + 200;
+// Total bytes of the priority-slice files.
+const PRIORITY_BYTES = 100 + 50 + 2 * MB + 80 + 200 + 300 * 1024;
 
 let fetchCalls;
 
@@ -79,12 +80,34 @@ describe("prefetchVaultContent slicing", () => {
     expect(fetchCalls[1]).toContain("plugins/fake/main.js");
   });
 
-  it("leaves plugin data.json to the bulk slice, not priority", async () => {
+  it("promotes plugin data.json into the priority slice", async () => {
     const result = prefetchVaultContent("v", tree, makeCache());
     await result.bulk;
 
-    expect(fetchCalls[0]).not.toContain(".obsidian/plugins/big/data.json");
-    expect(fetchCalls[1]).toContain(".obsidian/plugins/big/data.json");
+    expect(fetchCalls[0]).toContain(".obsidian/plugins/big/data.json");
+    expect(fetchCalls[1]).not.toContain(".obsidian/plugins/big/data.json");
+  });
+
+  it("admits core entry files before data.json, so a large data.json cannot evict a core file", async () => {
+    // The three 3 MB main.js fill 9 MB of the 10 MB priority budget, leaving no room for the 3 MB data.json.
+    const t = {
+      ".obsidian/plugins/a/main.js": { type: "file", size: 3 * MB },
+      ".obsidian/plugins/b/main.js": { type: "file", size: 3 * MB },
+      ".obsidian/plugins/c/main.js": { type: "file", size: 3 * MB },
+      ".obsidian/plugins/a/data.json": { type: "file", size: 3 * MB },
+    };
+
+    const result = prefetchVaultContent("v", t, makeCache());
+    await result.bulk;
+
+    expect(fetchCalls[0]).toEqual(
+      expect.arrayContaining([
+        ".obsidian/plugins/a/main.js",
+        ".obsidian/plugins/b/main.js",
+        ".obsidian/plugins/c/main.js",
+      ]),
+    );
+    expect(fetchCalls[0]).not.toContain(".obsidian/plugins/a/data.json");
   });
 
   it("caps the priority slice at its own byte budget", async () => {

--- a/packages/shim/src/fs/promises.js
+++ b/packages/shim/src/fs/promises.js
@@ -3,6 +3,7 @@ import {
   bufferWrite,
   cancelPending,
   COALESCE_MAX_BYTES,
+  enqueue,
   enqueueWrite,
   hasPending,
   initWriteCoalescer,
@@ -17,9 +18,17 @@ import {
 } from "./transforms.js";
 import { hasVirtualFile, getVirtualFile } from "./virtual-files.js";
 import { realpathSync } from "./realpath.js";
+import { initWriteDurability, onFailure } from "./write-durability.js";
 
 export function createFsPromises(metadataCache, contentCache, transport) {
   initWriteCoalescer(transport);
+  initWriteDurability(transport, enqueue);
+
+  // On give-up, drop the optimistic content so a re-read returns server truth.
+  // Metadata is left as-is: a reconciling stat would also fail (server unreachable) and deleting on that would lose a live file.
+  onFailure((failedPath) => {
+    contentCache.invalidate(failedPath);
+  });
 
   return {
     async stat(path) {
@@ -182,7 +191,12 @@ export function createFsPromises(metadataCache, contentCache, transport) {
         cancelPending(resolved);
       }
 
-      await enqueueWrite(resolved, transformed, encoding, applyResult);
+      try {
+        await enqueueWrite(resolved, transformed, encoding, applyResult);
+      } catch {
+        // The durability queue owns retrying a failed write, so resolve optimistically.
+        // A lost write surfaces through the status-bar signal and the give-up Notice.
+      }
     },
 
     async appendFile(path, data, encoding) {
@@ -351,7 +365,7 @@ export function createFsPromises(metadataCache, contentCache, transport) {
         },
 
         async close() {
-          // Nothing to clean up  -  data is in memory
+          // Nothing to clean up; data is in memory.
         },
       };
     },

--- a/packages/shim/src/fs/promises.js
+++ b/packages/shim/src/fs/promises.js
@@ -1,4 +1,13 @@
 import { markLocalOp } from "./echo-guard.js";
+import {
+  bufferWrite,
+  cancelPending,
+  COALESCE_MAX_BYTES,
+  enqueueWrite,
+  hasPending,
+  initWriteCoalescer,
+  isBooting,
+} from "./write-coalescer.js";
 import { isInputCachePath, inputCacheGet } from "./input-cache.js";
 import {
   applyReadTransform,
@@ -10,6 +19,8 @@ import { hasVirtualFile, getVirtualFile } from "./virtual-files.js";
 import { realpathSync } from "./realpath.js";
 
 export function createFsPromises(metadataCache, contentCache, transport) {
+  initWriteCoalescer(transport);
+
   return {
     async stat(path) {
       const resolved = resolvePath(path);
@@ -138,13 +149,21 @@ export function createFsPromises(metadataCache, contentCache, transport) {
       const resolved = resolvePath(path);
       const transformed = applyWriteTransform(resolved, data);
 
-      markLocalOp(resolved);
       contentCache.set(resolved, transformed);
 
       const size =
         typeof transformed === "string"
           ? transformed.length
           : transformed.byteLength || 0;
+
+      const applyResult = (result) => {
+        metadataCache.set(resolved, {
+          type: "file",
+          size: result.size || size,
+          mtime: result.mtime,
+          ctime: metadataCache.get(resolved)?.ctime || Date.now(),
+        });
+      };
 
       metadataCache.set(resolved, {
         type: "file",
@@ -153,16 +172,17 @@ export function createFsPromises(metadataCache, contentCache, transport) {
         ctime: metadataCache.get(resolved)?.ctime || Date.now(),
       });
 
-      const result = await transport.writeFile(resolved, transformed, encoding);
-
-      if (result.mtime) {
-        metadataCache.set(resolved, {
-          type: "file",
-          size: result.size || size,
-          mtime: result.mtime,
-          ctime: metadataCache.get(resolved)?.ctime || Date.now(),
-        });
+      if (isBooting() && size <= COALESCE_MAX_BYTES) {
+        bufferWrite(resolved, transformed, encoding, applyResult);
+        return;
       }
+
+      // An awaited write supersedes a still-buffered one for this path.
+      if (hasPending(resolved)) {
+        cancelPending(resolved);
+      }
+
+      await enqueueWrite(resolved, transformed, encoding, applyResult);
     },
 
     async appendFile(path, data, encoding) {
@@ -273,13 +293,17 @@ export function createFsPromises(metadataCache, contentCache, transport) {
 
     async utimes(path, atime, mtime) {
       const resolved = resolvePath(path);
-
-      await transport.utimes(resolved, atime, mtime);
       const meta = metadataCache.get(resolved);
+
       if (meta) {
         meta.mtime = typeof mtime === "number" ? mtime : mtime.getTime();
         metadataCache.set(resolved, meta);
       }
+
+      // mtime is non-critical, so flush it in the background instead of awaiting.
+      transport.utimes(resolved, atime, mtime).catch((e) => {
+        console.error("[shim:fs] utimes background flush failed:", resolved, e);
+      });
     },
 
     async chmod() {

--- a/packages/shim/src/fs/sync.js
+++ b/packages/shim/src/fs/sync.js
@@ -7,6 +7,7 @@ import {
   resolvePathInfo,
 } from "./transforms.js";
 import { hasVirtualFile, getVirtualFile } from "./virtual-files.js";
+import { trackWrite } from "./write-durability.js";
 
 export function createFsSync(metadataCache, contentCache, transport) {
   return {
@@ -173,14 +174,13 @@ export function createFsSync(metadataCache, contentCache, transport) {
         ctime: metadataCache.get(resolved)?.ctime || Date.now(),
       });
 
-      // Fire-and-forget async send to server
-      transport.writeFile(resolved, transformed, encoding).catch((e) => {
-        console.error(
-          "[shim:fs] writeFileSync background save failed:",
-          resolved,
-          e,
-        );
-      });
+      // Fire-and-forget async send, tracked silently: retries with backoff and gives up without surfacing.
+      const track = trackWrite(resolved, { silent: true });
+
+      transport.writeFile(resolved, transformed, encoding).then(
+        () => track.success(),
+        () => track.failure(transformed, encoding, null),
+      );
     },
 
     unlinkSync(path) {

--- a/packages/shim/src/fs/write-coalescer.js
+++ b/packages/shim/src/fs/write-coalescer.js
@@ -1,6 +1,7 @@
 // Coalesces boot-window writes per path so they flush in a few round-trips instead of one per save.
 
 import { markLocalOp } from "./echo-guard.js";
+import { trackWrite } from "./write-durability.js";
 
 const QUIET_MS = 100; // flush a path this long after its last write
 const MAX_WAIT_MS = 2000; // but never hold a buffered write longer than this
@@ -45,18 +46,28 @@ export function initWriteCoalescer(t) {
 
 function performWrite(path, data, encoding, onResult) {
   markLocalOp(path);
+  const track = trackWrite(path);
 
-  return transport.writeFile(path, data, encoding).then((result) => {
-    if (result && result.mtime && onResult) {
-      onResult(result);
-    }
+  return transport.writeFile(path, data, encoding).then(
+    (result) => {
+      track.success();
 
-    return result;
-  });
+      if (result && result.mtime && onResult) {
+        onResult(result);
+      }
+
+      return result;
+    },
+    (err) => {
+      // put the failed write in the durability queue, which retries it in the background.
+      track.failure(data, encoding, onResult);
+      throw err;
+    },
+  );
 }
 
 // Run a write only after any in-flight write to the same path completes.
-function enqueue(path, run) {
+export function enqueue(path, run) {
   const prev = tails.get(path) || Promise.resolve();
   const result = prev.then(run, run);
   const tail = result.catch(() => {});
@@ -84,8 +95,8 @@ function doFlush(path) {
 
   enqueue(path, () =>
     performWrite(path, entry.data, entry.encoding, entry.onResult),
-  ).catch((e) => {
-    console.error("[shim:fs] coalesced writeFile flush failed:", path, e);
+  ).catch(() => {
+    // performWrite handed the failure to the durability queue; nothing more to do here.
   });
 }
 

--- a/packages/shim/src/fs/write-coalescer.js
+++ b/packages/shim/src/fs/write-coalescer.js
@@ -1,0 +1,132 @@
+// Coalesces boot-window writes per path so they flush in a few round-trips instead of one per save.
+
+import { markLocalOp } from "./echo-guard.js";
+
+const QUIET_MS = 100; // flush a path this long after its last write
+const MAX_WAIT_MS = 2000; // but never hold a buffered write longer than this
+
+// Bodies over transport's keepalive cap would not survive a pagehide flush, so they are not coalesced.
+export const COALESCE_MAX_BYTES = 32 * 1024;
+
+let transport = null;
+let listenersBound = false;
+const pending = new Map(); // path -> { data, encoding, onResult, quiet, max }
+const tails = new Map(); // path -> promise serializing that path's in-flight write
+
+// Set by init.js on the bootstrap path, cleared at layout-ready.
+export function isBooting() {
+  return typeof window !== "undefined" && window.__ignisBooting === true;
+}
+
+export function initWriteCoalescer(t) {
+  transport = t;
+
+  if (
+    listenersBound ||
+    typeof window === "undefined" ||
+    typeof window.addEventListener !== "function"
+  ) {
+    return;
+  }
+
+  listenersBound = true;
+
+  // Deliver buffered writes if the tab is closed or hidden mid-boot.
+  window.addEventListener("pagehide", flushAll);
+
+  if (typeof document !== "undefined" && document.addEventListener) {
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "hidden") {
+        flushAll();
+      }
+    });
+  }
+}
+
+function performWrite(path, data, encoding, onResult) {
+  markLocalOp(path);
+
+  return transport.writeFile(path, data, encoding).then((result) => {
+    if (result && result.mtime && onResult) {
+      onResult(result);
+    }
+
+    return result;
+  });
+}
+
+// Run a write only after any in-flight write to the same path completes.
+function enqueue(path, run) {
+  const prev = tails.get(path) || Promise.resolve();
+  const result = prev.then(run, run);
+  const tail = result.catch(() => {});
+
+  tails.set(path, tail);
+  tail.then(() => {
+    if (tails.get(path) === tail) {
+      tails.delete(path);
+    }
+  });
+
+  return result;
+}
+
+function doFlush(path) {
+  const entry = pending.get(path);
+
+  if (!entry) {
+    return;
+  }
+
+  clearTimeout(entry.quiet);
+  clearTimeout(entry.max);
+  pending.delete(path);
+
+  enqueue(path, () =>
+    performWrite(path, entry.data, entry.encoding, entry.onResult),
+  ).catch((e) => {
+    console.error("[shim:fs] coalesced writeFile flush failed:", path, e);
+  });
+}
+
+export function bufferWrite(path, data, encoding, onResult) {
+  const entry = pending.get(path) || { max: null };
+
+  clearTimeout(entry.quiet);
+  entry.data = data;
+  entry.encoding = encoding;
+  entry.onResult = onResult;
+  entry.quiet = setTimeout(() => doFlush(path), QUIET_MS);
+
+  if (!entry.max) {
+    entry.max = setTimeout(() => doFlush(path), MAX_WAIT_MS);
+  }
+
+  pending.set(path, entry);
+}
+
+export function enqueueWrite(path, data, encoding, onResult) {
+  return enqueue(path, () => performWrite(path, data, encoding, onResult));
+}
+
+export function cancelPending(path) {
+  const entry = pending.get(path);
+
+  if (!entry) {
+    return;
+  }
+
+  clearTimeout(entry.quiet);
+  clearTimeout(entry.max);
+  pending.delete(path);
+}
+
+export function hasPending(path) {
+  return pending.has(path);
+}
+
+function flushAll() {
+  for (const path of Array.from(pending.keys())) {
+    doFlush(path);
+  }
+}

--- a/packages/shim/src/fs/write-coalescer.test.js
+++ b/packages/shim/src/fs/write-coalescer.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  initWriteCoalescer,
+  bufferWrite,
+  cancelPending,
+  enqueueWrite,
+  hasPending,
+} from "./write-coalescer.js";
+import { isRecentLocalOp } from "./echo-guard.js";
+
+function makeTransport() {
+  const calls = [];
+
+  return {
+    calls,
+    writeFile: vi.fn(async (path, data, encoding) => {
+      calls.push({ path, data, encoding });
+      return { mtime: 123, size: typeof data === "string" ? data.length : 0 };
+    }),
+  };
+}
+
+describe("client write coalescer", () => {
+  let transport;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    transport = makeTransport();
+    initWriteCoalescer(transport);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("coalesces a burst of same-path writes into one flush with the last content", async () => {
+    bufferWrite("types.json", "v1", "utf-8");
+    bufferWrite("types.json", "v2", "utf-8");
+    bufferWrite("types.json", "v3", "utf-8");
+
+    expect(transport.writeFile).not.toHaveBeenCalled();
+    expect(hasPending("types.json")).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(transport.writeFile).toHaveBeenCalledTimes(1);
+    expect(transport.calls[0]).toMatchObject({ path: "types.json", data: "v3" });
+    expect(hasPending("types.json")).toBe(false);
+  });
+
+  it("flushes distinct paths independently", async () => {
+    bufferWrite("a.json", "a", "utf-8");
+    bufferWrite("b.json", "b", "utf-8");
+
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(transport.writeFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks the local op at flush time, not before, so the watcher echo is suppressed", async () => {
+    bufferWrite("c.json", "c", "utf-8");
+
+    expect(isRecentLocalOp("c.json")).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(isRecentLocalOp("c.json")).toBe(true);
+  });
+
+  it("invokes onResult with the server result after the flush", async () => {
+    const onResult = vi.fn();
+    bufferWrite("d.json", "d", "utf-8", onResult);
+
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(onResult).toHaveBeenCalledWith(
+      expect.objectContaining({ mtime: 123 }),
+    );
+  });
+
+  it("cancelPending drops a buffered write without sending it", async () => {
+    bufferWrite("e.json", "e", "utf-8");
+    cancelPending("e.json");
+
+    await vi.advanceTimersByTimeAsync(2500);
+
+    expect(transport.writeFile).not.toHaveBeenCalled();
+    expect(hasPending("e.json")).toBe(false);
+  });
+
+  it("forces a flush at the max wait under continuous writes", async () => {
+    // Write faster than the quiet window so the quiet timer keeps resetting; only the max wait fires.
+    for (let i = 0; i < 45; i++) {
+      bufferWrite("g.json", "g" + i, "utf-8");
+      await vi.advanceTimersByTimeAsync(50);
+    }
+
+    expect(transport.writeFile).toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(150);
+  });
+
+  it("serializes same-path writes: the second does not start until the first settles", async () => {
+    let releaseA;
+    const started = [];
+
+    transport.writeFile = vi.fn((path, data) => {
+      started.push(data);
+
+      if (data === "A") {
+        return new Promise((res) => {
+          releaseA = () => res({ mtime: 1 });
+        });
+      }
+
+      return Promise.resolve({ mtime: 1 });
+    });
+
+    const pA = enqueueWrite("n.md", "A", "utf-8");
+    const pB = enqueueWrite("n.md", "B", "utf-8");
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toEqual(["A"]); // B is blocked behind the in-flight A
+
+    releaseA();
+    await pA;
+    await pB;
+    expect(started).toEqual(["A", "B"]);
+  });
+
+  it("an awaited write waits for an in-flight buffered flush to the same path (no reorder)", async () => {
+    let releaseFlush;
+    const started = [];
+
+    transport.writeFile = vi.fn((path, data) => {
+      started.push(data);
+
+      if (data === "boot") {
+        return new Promise((res) => {
+          releaseFlush = () => res({ mtime: 1 });
+        });
+      }
+
+      return Promise.resolve({ mtime: 2 });
+    });
+
+    bufferWrite("n.md", "boot", "utf-8");
+    await vi.advanceTimersByTimeAsync(150);
+
+    // The buffered flush is now in flight and no longer "pending".
+    expect(started).toEqual(["boot"]);
+    expect(hasPending("n.md")).toBe(false);
+
+    const pPost = enqueueWrite("n.md", "post", "utf-8");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toEqual(["boot"]); // blocked behind the in-flight flush
+
+    releaseFlush();
+    await pPost;
+    expect(started).toEqual(["boot", "post"]); // strictly after the boot flush
+  });
+});

--- a/packages/shim/src/fs/write-durability.js
+++ b/packages/shim/src/fs/write-durability.js
@@ -1,0 +1,350 @@
+// Always-on write durability: a failed writeFile is retried with backoff.
+// A non-silent write drives the status-bar dirty signal and fires a failure event on give-up; a silent write retries without surfacing.
+
+import { markLocalOp } from "./echo-guard.js";
+
+// Only a write lagging past this shows as pending.
+const PENDING_AFTER_MS = 1000;
+
+// Retry delays; the last repeats once exhausted.
+const BACKOFF_MS = [1000, 2000, 4000, 8000, 16000, 30000];
+
+const MAX_ATTEMPTS = 8;
+
+let transport = null;
+
+// Retries reuse the same per-path serializer as fresh writes, so a stale retry cannot clobber a newer write.
+let serialize = (path, run) => run();
+
+// path -> { gen, status, silent, overThreshold, data, encoding, onResult, attempts, startTimer, retryTimer }
+// status "inflight" | "retrying" | "failed"; a failed non-silent entry is kept out of the aggregate but retained for retryAll().
+const entries = new Map();
+
+// Bumped on every fresh write to a path, so a stale timer or settled promise from a superseded write bows out.
+let genCounter = 0;
+
+// "clean" | "pending". Failure is an event, not a state, so it never appears here.
+let state = "clean";
+const stateSubs = new Set();
+const failureSubs = new Set();
+const failureChangeSubs = new Set();
+
+export function initWriteDurability(t, serializeFn) {
+  transport = t;
+
+  if (serializeFn) {
+    serialize = serializeFn;
+  }
+}
+
+function discard(path) {
+  const entry = entries.get(path);
+
+  if (!entry) {
+    return;
+  }
+
+  clearTimeout(entry.startTimer);
+  clearTimeout(entry.retryTimer);
+  entries.delete(path);
+}
+
+// An entry still trying (in flight past the threshold, or retrying) contributes to "pending".
+function contributesPending(entry) {
+  if (entry.silent || entry.status === "failed") {
+    return false;
+  }
+
+  return (
+    entry.status === "retrying" ||
+    (entry.status === "inflight" && entry.overThreshold)
+  );
+}
+
+function recompute() {
+  let next = "clean";
+
+  for (const entry of entries.values()) {
+    if (contributesPending(entry)) {
+      next = "pending";
+      break;
+    }
+  }
+
+  if (next === state) {
+    return;
+  }
+
+  state = next;
+
+  for (const fn of stateSubs) {
+    try {
+      fn(state);
+    } catch (e) {
+      console.error("[shim:fs] write-durability subscriber threw:", e);
+    }
+  }
+}
+
+function emitFailure(path) {
+  for (const fn of failureSubs) {
+    try {
+      fn(path);
+    } catch (e) {
+      console.error("[shim:fs] write-durability failure subscriber threw:", e);
+    }
+  }
+}
+
+function emitFailureChange() {
+  for (const fn of failureChangeSubs) {
+    try {
+      fn();
+    } catch (e) {
+      console.error(
+        "[shim:fs] write-durability failure-change subscriber threw:",
+        e,
+      );
+    }
+  }
+}
+
+function scheduleRetry(path, gen) {
+  const entry = entries.get(path);
+
+  if (!entry || entry.gen !== gen) {
+    return;
+  }
+
+  const delay = BACKOFF_MS[Math.min(entry.attempts - 1, BACKOFF_MS.length - 1)];
+
+  clearTimeout(entry.retryTimer);
+  entry.retryTimer = setTimeout(() => attempt(path, gen), delay);
+}
+
+function attempt(path, gen) {
+  const entry = entries.get(path);
+
+  if (!entry || entry.gen !== gen || !transport) {
+    return;
+  }
+
+  // Serialize behind any in-flight write; if a newer write superseded us while queued, skip the send.
+  serialize(path, () => {
+    const e = entries.get(path);
+
+    if (!e || e.gen !== gen) {
+      return Promise.resolve(null);
+    }
+
+    markLocalOp(path);
+    return transport.writeFile(path, e.data, e.encoding);
+  }).then(
+    (result) => {
+      const e = entries.get(path);
+
+      if (!e || e.gen !== gen) {
+        return;
+      }
+
+      if (e.onResult && result && result.mtime) {
+        e.onResult(result);
+      }
+
+      discard(path);
+      recompute();
+    },
+    () => {
+      const e = entries.get(path);
+
+      if (!e || e.gen !== gen) {
+        return;
+      }
+
+      e.attempts += 1;
+
+      if (e.attempts <= MAX_ATTEMPTS) {
+        scheduleRetry(path, gen);
+        return;
+      }
+
+      if (e.silent) {
+        // Silent writes give up without user surfacing; the optimistic cache staleness clears on reload.
+        console.error("[shim:fs] write durability gave up (silent):", path);
+        discard(path);
+        recompute();
+      } else {
+        e.status = "failed";
+        recompute();
+        emitFailure(path);
+      }
+    },
+  );
+}
+
+// Track one write; the caller reports the outcome on the returned handle.
+// The captured gen is checked on both outcome paths, so a superseded write never mutates a newer entry; opts.silent suppresses surfacing.
+export function trackWrite(path, opts) {
+  // A fresh write to a given-up path retires its failure, so any surface showing it must reconcile.
+  const prev = entries.get(path);
+  const supersededFailure = !!(
+    prev &&
+    prev.status === "failed" &&
+    !prev.silent
+  );
+
+  discard(path);
+
+  const gen = ++genCounter;
+  const entry = {
+    gen,
+    status: "inflight",
+    silent: !!(opts && opts.silent),
+    overThreshold: false,
+    startTimer: null,
+    retryTimer: null,
+  };
+
+  entry.startTimer = setTimeout(() => {
+    const e = entries.get(path);
+
+    if (e && e.gen === gen && e.status === "inflight") {
+      e.overThreshold = true;
+      recompute();
+    }
+  }, PENDING_AFTER_MS);
+
+  entries.set(path, entry);
+
+  // Superseding a prior pending/retrying entry can clear the aggregate; the fresh write starts clean.
+  recompute();
+
+  if (supersededFailure) {
+    emitFailureChange();
+  }
+
+  return {
+    success() {
+      const e = entries.get(path);
+
+      if (e && e.gen === gen) {
+        discard(path);
+        recompute();
+      }
+    },
+
+    failure(data, encoding, onResult) {
+      const e = entries.get(path);
+
+      if (!e || e.gen !== gen) {
+        return;
+      }
+
+      clearTimeout(e.startTimer);
+      e.data = data;
+      e.encoding = encoding;
+      e.onResult = onResult;
+      e.status = "retrying";
+      e.overThreshold = true;
+      e.attempts = 1;
+
+      scheduleRetry(path, gen);
+      recompute();
+    },
+  };
+}
+
+export function getState() {
+  return state;
+}
+
+export function onStateChange(handler) {
+  stateSubs.add(handler);
+
+  return () => {
+    stateSubs.delete(handler);
+  };
+}
+
+// Fires the path of each non-silent write that has permanently given up after exhausting its retries.
+export function onFailure(handler) {
+  failureSubs.add(handler);
+
+  return () => {
+    failureSubs.delete(handler);
+  };
+}
+
+// Fires when a given-up path is retired by a newer write; read the current set via listFailed().
+export function onFailureChange(handler) {
+  failureChangeSubs.add(handler);
+
+  return () => {
+    failureChangeSubs.delete(handler);
+  };
+}
+
+export function listFailed() {
+  const failed = [];
+
+  for (const [path, entry] of entries) {
+    if (entry.status === "failed" && !entry.silent) {
+      failed.push(path);
+    }
+  }
+
+  return failed;
+}
+
+export function getDetail() {
+  let pending = 0;
+  let retrying = 0;
+
+  for (const entry of entries.values()) {
+    if (entry.silent || entry.status === "failed") {
+      continue;
+    }
+
+    if (entry.status === "retrying") {
+      retrying += 1;
+      pending += 1;
+    } else if (entry.status === "inflight" && entry.overThreshold) {
+      pending += 1;
+    }
+  }
+
+  return { pending, retrying };
+}
+
+export function retryAll() {
+  for (const [path, entry] of entries) {
+    if (entry.status === "failed" && !entry.silent) {
+      entry.status = "retrying";
+      entry.attempts = 1;
+      attempt(path, entry.gen);
+    }
+  }
+
+  recompute();
+}
+
+// Test-only: count of tracked entries.
+export function _size() {
+  return entries.size;
+}
+
+// Test-only: clear all timers, state, and subscribers.
+export function _reset() {
+  for (const entry of entries.values()) {
+    clearTimeout(entry.startTimer);
+    clearTimeout(entry.retryTimer);
+  }
+
+  entries.clear();
+  state = "clean";
+  genCounter = 0;
+  serialize = (path, run) => run();
+  stateSubs.clear();
+  failureSubs.clear();
+  failureChangeSubs.clear();
+}

--- a/packages/shim/src/fs/write-durability.test.js
+++ b/packages/shim/src/fs/write-durability.test.js
@@ -1,0 +1,412 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as wd from "./write-durability.js";
+
+let transport;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  wd._reset();
+  transport = { writeFile: vi.fn().mockResolvedValue({ mtime: 1, size: 1 }) };
+  wd.initWriteDurability(transport);
+});
+
+afterEach(() => {
+  wd._reset();
+  vi.useRealTimers();
+});
+
+describe("pending threshold", () => {
+  it("does not go pending for a write that resolves before the threshold", () => {
+    const track = wd.trackWrite("a.md");
+
+    vi.advanceTimersByTime(500);
+    track.success();
+    vi.advanceTimersByTime(1000);
+
+    expect(wd.getState()).toBe("clean");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("goes pending for a write still in flight past the threshold", () => {
+    const track = wd.trackWrite("a.md");
+
+    expect(wd.getState()).toBe("clean");
+
+    vi.advanceTimersByTime(1000);
+
+    expect(wd.getState()).toBe("pending");
+    expect(wd.getDetail()).toEqual({ pending: 1, retrying: 0 });
+
+    track.success();
+
+    expect(wd.getState()).toBe("clean");
+  });
+
+  it("does not re-emit while a second path crosses the threshold during pending", () => {
+    const seen = [];
+    wd.onStateChange((s) => seen.push(s));
+
+    const a = wd.trackWrite("a.md");
+    wd.trackWrite("b.md");
+    vi.advanceTimersByTime(1000);
+
+    expect(seen).toEqual(["pending"]);
+
+    a.success();
+
+    expect(seen).toEqual(["pending"]);
+  });
+});
+
+describe("retry on failure", () => {
+  it("retries a failed write and clears once it lands", async () => {
+    const track = wd.trackWrite("a.md");
+    track.failure("payload", "utf-8", null);
+
+    expect(wd.getState()).toBe("pending");
+    expect(wd.getDetail()).toEqual({ pending: 1, retrying: 1 });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(transport.writeFile).toHaveBeenCalledWith("a.md", "payload", "utf-8");
+    expect(wd.getState()).toBe("clean");
+  });
+
+  it("runs onResult when a retry succeeds", async () => {
+    const onResult = vi.fn();
+    const track = wd.trackWrite("a.md");
+    track.failure("d", "utf-8", onResult);
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(onResult).toHaveBeenCalledWith({ mtime: 1, size: 1 });
+  });
+
+  it("gives up after the cap: fires onFailure, lists the path, aggregate returns clean", async () => {
+    transport.writeFile.mockRejectedValue(new Error("offline"));
+    const failed = [];
+    wd.onFailure((p) => failed.push(p));
+
+    const track = wd.trackWrite("a.md");
+    track.failure("d", "utf-8", null);
+
+    for (let i = 0; i < 9; i++) {
+      await vi.advanceTimersByTimeAsync(30000);
+    }
+
+    expect(failed).toEqual(["a.md"]);
+    expect(wd.listFailed()).toEqual(["a.md"]);
+    expect(wd.getState()).toBe("clean");
+    expect(wd.getDetail()).toEqual({ pending: 0, retrying: 0 });
+  });
+
+  it("a lingering failed entry does not mask a later pending write", async () => {
+    transport.writeFile.mockRejectedValue(new Error("offline"));
+
+    const t1 = wd.trackWrite("a.md");
+    t1.failure("d", "utf-8", null);
+
+    for (let i = 0; i < 9; i++) {
+      await vi.advanceTimersByTimeAsync(30000);
+    }
+
+    expect(wd.listFailed()).toEqual(["a.md"]);
+
+    const b = wd.trackWrite("b.md");
+    vi.advanceTimersByTime(1000);
+
+    expect(wd.getState()).toBe("pending");
+
+    b.success();
+
+    // With b.md landed, the lingering failed a.md must not keep the aggregate pending.
+    expect(wd.getState()).toBe("clean");
+    expect(wd.listFailed()).toEqual(["a.md"]);
+  });
+});
+
+describe("silent (config) writes", () => {
+  it("never contributes to the user-facing state or detail", () => {
+    const seen = [];
+    wd.onStateChange((s) => seen.push(s));
+
+    wd.trackWrite("config.json", { silent: true });
+    vi.advanceTimersByTime(1000);
+
+    expect(wd.getState()).toBe("clean");
+    expect(wd.getDetail()).toEqual({ pending: 0, retrying: 0 });
+    expect(seen).toEqual([]);
+  });
+
+  it("still retries on failure but never fires onFailure or lists", async () => {
+    transport.writeFile.mockRejectedValue(new Error("offline"));
+    const failed = [];
+    wd.onFailure((p) => failed.push(p));
+
+    const track = wd.trackWrite("config.json", { silent: true });
+    track.failure("cfg", "utf-8", null);
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(transport.writeFile).toHaveBeenCalledWith(
+      "config.json",
+      "cfg",
+      "utf-8",
+    );
+
+    for (let i = 0; i < 9; i++) {
+      await vi.advanceTimersByTimeAsync(30000);
+    }
+
+    expect(failed).toEqual([]);
+    expect(wd.listFailed()).toEqual([]);
+    expect(wd.getState()).toBe("clean");
+    // A silent give-up must discard the entry, not leave it lingering in the map forever.
+    expect(wd._size()).toBe(0);
+  });
+});
+
+describe("supersession", () => {
+  it("a fresh write supersedes a pending retry and cancels the old retry", async () => {
+    const t1 = wd.trackWrite("a.md");
+    t1.failure("old", "utf-8", null);
+
+    expect(wd.getState()).toBe("pending");
+
+    wd.trackWrite("a.md");
+
+    expect(wd.getState()).toBe("clean");
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // The old retry timer was cleared, so no write of any kind fires for the superseded entry.
+    expect(transport.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("a settled write under a superseded gen does not mutate the newer entry", async () => {
+    let resolveOld;
+    transport.writeFile.mockImplementationOnce(
+      () =>
+        new Promise((res) => {
+          resolveOld = res;
+        }),
+    );
+
+    const t1 = wd.trackWrite("a.md");
+    t1.failure("old", "utf-8", null);
+
+    // Fire the retry; its transport.writeFile is now pending under gen 1.
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(transport.writeFile).toHaveBeenCalledWith("a.md", "old", "utf-8");
+
+    // A fresh write supersedes (gen 2) while the gen-1 write is still in flight.
+    const t2 = wd.trackWrite("a.md");
+
+    expect(wd._size()).toBe(1);
+
+    // The gen-1 write resolves late; the gen check must keep it from discarding the gen-2 entry.
+    resolveOld({ mtime: 1, size: 1 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(wd._size()).toBe(1);
+
+    vi.advanceTimersByTime(1000);
+
+    expect(wd.getState()).toBe("pending");
+
+    t2.success();
+
+    expect(wd.getState()).toBe("clean");
+  });
+
+  it("a stale handle's failure() after supersession is a no-op", () => {
+    const t1 = wd.trackWrite("a.md");
+    const t2 = wd.trackWrite("a.md");
+
+    t1.failure("stale", "utf-8", null);
+
+    expect(wd.getState()).toBe("clean");
+    expect(wd.getDetail()).toEqual({ pending: 0, retrying: 0 });
+
+    t2.success();
+
+    expect(wd.getState()).toBe("clean");
+  });
+});
+
+describe("retryAll", () => {
+  it("re-attempts a given-up write and clears on success", async () => {
+    transport.writeFile.mockRejectedValue(new Error("offline"));
+
+    const track = wd.trackWrite("a.md");
+    track.failure("d", "utf-8", null);
+
+    for (let i = 0; i < 9; i++) {
+      await vi.advanceTimersByTimeAsync(30000);
+    }
+
+    expect(wd.listFailed()).toEqual(["a.md"]);
+
+    transport.writeFile.mockResolvedValue({ mtime: 1, size: 1 });
+    wd.retryAll();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(wd.listFailed()).toEqual([]);
+    expect(wd.getState()).toBe("clean");
+  });
+
+  it("a retried write that fails again re-enters backoff and gives up again", async () => {
+    transport.writeFile.mockRejectedValue(new Error("offline"));
+    const failed = [];
+    wd.onFailure((p) => failed.push(p));
+
+    const track = wd.trackWrite("a.md");
+    track.failure("d", "utf-8", null);
+
+    for (let i = 0; i < 9; i++) {
+      await vi.advanceTimersByTimeAsync(30000);
+    }
+
+    expect(failed).toEqual(["a.md"]);
+
+    wd.retryAll();
+
+    for (let i = 0; i < 9; i++) {
+      await vi.advanceTimersByTimeAsync(30000);
+    }
+
+    expect(failed).toEqual(["a.md", "a.md"]);
+  });
+});
+
+describe("getDetail", () => {
+  it("counts inflight-past-threshold as pending, not retrying", () => {
+    wd.trackWrite("a.md");
+    vi.advanceTimersByTime(1000);
+
+    expect(wd.getDetail()).toEqual({ pending: 1, retrying: 0 });
+  });
+
+  it("counts a mix of retrying and inflight-pending", () => {
+    const t1 = wd.trackWrite("a.md");
+    t1.failure("d", "utf-8", null);
+    wd.trackWrite("b.md");
+    vi.advanceTimersByTime(1000);
+
+    expect(wd.getDetail()).toEqual({ pending: 2, retrying: 1 });
+  });
+});
+
+describe("subscriber resilience", () => {
+  it("one throwing state subscriber does not block others", () => {
+    const seen = [];
+    wd.onStateChange(() => {
+      throw new Error("bad");
+    });
+    wd.onStateChange((s) => seen.push(s));
+
+    wd.trackWrite("a.md");
+    vi.advanceTimersByTime(1000);
+
+    expect(seen).toEqual(["pending"]);
+  });
+
+  it("one throwing failure subscriber does not block others", async () => {
+    transport.writeFile.mockRejectedValue(new Error("offline"));
+    const seen = [];
+    wd.onFailure(() => {
+      throw new Error("bad");
+    });
+    wd.onFailure((p) => seen.push(p));
+
+    const track = wd.trackWrite("a.md");
+    track.failure("d", "utf-8", null);
+
+    for (let i = 0; i < 9; i++) {
+      await vi.advanceTimersByTimeAsync(30000);
+    }
+
+    expect(seen).toEqual(["a.md"]);
+  });
+});
+
+describe("retry serialization", () => {
+  it("routes retries through the injected serializer", async () => {
+    const serialize = vi.fn((path, run) => run());
+    wd.initWriteDurability(transport, serialize);
+
+    const track = wd.trackWrite("a.md");
+    track.failure("d", "utf-8", null);
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(serialize).toHaveBeenCalledWith("a.md", expect.any(Function));
+    expect(transport.writeFile).toHaveBeenCalledWith("a.md", "d", "utf-8");
+  });
+
+  it("skips a queued retry that a newer write superseded before its turn", async () => {
+    // A serializer that holds the run until released, mimicking a slow in-flight write ahead of it.
+    let release;
+    const gate = new Promise((res) => {
+      release = res;
+    });
+    const serialize = vi.fn((path, run) => gate.then(run, run));
+    wd.initWriteDurability(transport, serialize);
+
+    const t1 = wd.trackWrite("a.md");
+    t1.failure("old", "utf-8", null);
+
+    // Fire the retry: it enters the serializer but is gated, not yet dispatched.
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(serialize).toHaveBeenCalledTimes(1);
+    expect(transport.writeFile).not.toHaveBeenCalled();
+
+    // A fresh write supersedes before the gated retry gets its turn.
+    wd.trackWrite("a.md");
+
+    // Release the gate; the retry's run sees the newer gen and must not dispatch the stale body.
+    release();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transport.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("onFailureChange", () => {
+  it("fires when a failed path is superseded, and listFailed drops it", async () => {
+    transport.writeFile.mockRejectedValue(new Error("offline"));
+    let fired = 0;
+    wd.onFailureChange(() => fired++);
+
+    const track = wd.trackWrite("a.md");
+    track.failure("d", "utf-8", null);
+
+    for (let i = 0; i < 9; i++) {
+      await vi.advanceTimersByTimeAsync(30000);
+    }
+
+    expect(wd.listFailed()).toEqual(["a.md"]);
+    expect(fired).toBe(0);
+
+    // A fresh write to the given-up path retires its failure.
+    wd.trackWrite("a.md");
+
+    expect(fired).toBe(1);
+    expect(wd.listFailed()).toEqual([]);
+  });
+
+  it("does not fire when superseding a still-retrying (not yet failed) write", () => {
+    let fired = 0;
+    wd.onFailureChange(() => fired++);
+
+    const t1 = wd.trackWrite("a.md");
+    t1.failure("d", "utf-8", null);
+    wd.trackWrite("a.md");
+
+    expect(fired).toBe(0);
+  });
+});

--- a/packages/shim/src/ignis-api.js
+++ b/packages/shim/src/ignis-api.js
@@ -1,7 +1,7 @@
 // Public Ignis API surface. The documented way for plugins (and Ignis-internal code) to reach shim services.
 // WIP, may expand to cover more shared functionality.
 
-export function installIgnisApi(wsClient) {
+export function installIgnisApi(wsClient, writes) {
   window.__ignis = window.__ignis || {};
 
   // Live getters so vault info reflects whatever init.js / vault-switch code has set.
@@ -23,6 +23,8 @@ export function installIgnisApi(wsClient) {
     isOpen: wsClient.isOpen,
     onStateChange: wsClient.onStateChange,
   };
+
+  window.__ignis.writes = writes;
 
   window.__ignis.plugins = window.__ignis.plugins || {};
 }

--- a/packages/shim/src/init.js
+++ b/packages/shim/src/init.js
@@ -13,6 +13,7 @@ import { setInputCacheLimits } from "./fs/input-cache.js";
 import { setDirectFetchHosts } from "./util/url.js";
 import { autoTrustDemoVaults, maybeProvisionDemoVault } from "./demo.js";
 import { initNativeMenuGuard } from "./native-menu-guard.js";
+import { initSpellcheckGuard } from "./spellcheck-guard.js";
 
 let bootstrapVirtualPlugins = [];
 
@@ -236,6 +237,7 @@ function resolveWorkspaceAndAppearance() {
   resolveWorkspaceName();
   loadPresetIfRequested();
   initNativeMenuGuard();
+  initSpellcheckGuard();
 }
 
 export function initialize() {

--- a/packages/shim/src/init.js
+++ b/packages/shim/src/init.js
@@ -267,6 +267,8 @@ export function initialize() {
       { onProgress: updateBootProgress },
     );
 
+    window.__ignisBooting = true;
+
     // Chain workspace/appearance resolution onto readiness so its config reads hit the warm priority slice instead of the network.
     window.__ignisBootReady = priority.then(resolveWorkspaceAndAppearance);
   } else {

--- a/packages/shim/src/loader.js
+++ b/packages/shim/src/loader.js
@@ -12,12 +12,29 @@ import {
 } from "./virtual-plugin-loader.js";
 import { wsClient } from "./ws-client.js";
 import { installIgnisApi } from "./ignis-api.js";
+import {
+  getState,
+  onStateChange,
+  onFailure,
+  onFailureChange,
+  listFailed,
+  retryAll,
+  getDetail,
+} from "./fs/write-durability.js";
 
 // __IGNIS_VERSION__ (semver) and __IGNIS_BUILD__ are replaced at build time.
 window.__ignis = { version: __IGNIS_VERSION__, build: __IGNIS_BUILD__ };
 window.__ignis_registerUI = registerUI;
 
-installIgnisApi(wsClient);
+installIgnisApi(wsClient, {
+  getState,
+  onStateChange,
+  onFailure,
+  onFailureChange,
+  listFailed,
+  retryAll,
+  getDetail,
+});
 
 const BRIDGE_MANIFEST = {
   id: "ignis-bridge",

--- a/packages/shim/src/loader.js
+++ b/packages/shim/src/loader.js
@@ -42,7 +42,16 @@ if (window.innerWidth < 600) {
   localStorage.removeItem("EmulateMobile");
 }
 
+// Fallback that ends the boot window if layout-ready never fires.
+setTimeout(() => {
+  window.__ignisBooting = false;
+}, 20000);
+
 initialize(); // vault config, metadata cache, plugin prompt
+
+function onLayoutReady() {
+  window.__ignisBooting = false;
+}
 
 // Connect the shared WebSocket after everything is initialized; watcher and live-toggle subscribers attach to the same client.
 if (window.__currentVaultId) {
@@ -52,6 +61,11 @@ if (window.__currentVaultId) {
 
 extractObsidianModule()
   .then(async () => {
+    // window.app exists once Obsidian's module is extracted.
+    if (window.app && window.app.workspace && window.app.workspace.onLayoutReady) {
+      window.app.workspace.onLayoutReady(onLayoutReady);
+    }
+
     // Dynamic import so the bridge's top-level obsidian import resolves after installRequire + extractObsidianModule.
     const mod = await import("@ignis/bridge");
     const IgnisBridgePlugin = mod.default || mod;

--- a/packages/shim/src/spellcheck-guard.js
+++ b/packages/shim/src/spellcheck-guard.js
@@ -1,0 +1,105 @@
+// Disable spellchecker dropdown since browser spellchecker cannot be set programmatically.
+// Direct users to system settings instead.
+
+import { detectBrowser } from "./browser-detect.js";
+import { copyText } from "./util/clipboard.js";
+
+// Each browser's language / spellcheck settings page. Safari has none: its spellcheck is OS-level.
+const SETTINGS_URLS = {
+  chrome: "chrome://settings/languages",
+  edge: "edge://settings/languages",
+  opera: "opera://settings/languages",
+  vivaldi: "vivaldi://settings/languages",
+  firefox: "about:preferences",
+  safari: null,
+};
+
+function flash(el, original, message) {
+  el.textContent = message;
+
+  setTimeout(() => {
+    el.textContent = original;
+  }, 1200);
+}
+
+function copyLink(url) {
+  const a = document.createElement("a");
+  a.textContent = url;
+  a.href = "#";
+  a.setAttribute("aria-label", "Copy " + url);
+  a.style.color = "inherit";
+  a.style.textDecoration = "underline";
+  a.style.cursor = "pointer";
+
+  a.addEventListener("click", (e) => {
+    e.preventDefault();
+
+    copyText(url).then(
+      () => flash(a, url, "Copied"),
+      () => flash(a, url, "Copy failed"),
+    );
+  });
+
+  return a;
+}
+
+function renderNotice(desc) {
+  const url = SETTINGS_URLS[detectBrowser()];
+
+  desc.textContent = "";
+  desc.style.color = "var(--text-error)";
+  desc.appendChild(
+    document.createTextNode("Ignis can't set browser spellchecker languages. "),
+  );
+
+  if (url) {
+    desc.appendChild(document.createTextNode("Please use "));
+    desc.appendChild(copyLink(url));
+    desc.appendChild(document.createTextNode(" (click to copy)."));
+  } else {
+    desc.appendChild(
+      document.createTextNode(
+        "Please enable spellcheck in your system settings.",
+      ),
+    );
+  }
+}
+
+function apply() {
+  document.querySelectorAll(".setting-item-name").forEach((nameEl) => {
+    if (!/spellcheck languages/i.test(nameEl.textContent)) {
+      return;
+    }
+
+    const item = nameEl.closest(".setting-item");
+
+    if (!item || item.__ignisSpellcheckGuarded) {
+      return;
+    }
+
+    const select = item.querySelector("select");
+
+    if (select) {
+      select.disabled = true;
+    }
+
+    const desc = item.querySelector(".setting-item-description");
+
+    if (desc) {
+      renderNotice(desc);
+    }
+
+    item.__ignisSpellcheckGuarded = true;
+  });
+}
+
+export function initSpellcheckGuard() {
+  const observer = new MutationObserver(apply);
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+
+  apply();
+}

--- a/packages/shim/src/util/clipboard.js
+++ b/packages/shim/src/util/clipboard.js
@@ -1,0 +1,28 @@
+// Copy a string to the clipboard, resolving on success and rejecting on failure.
+// navigator.clipboard needs a secure context, so fall back to a textarea + execCommand for plain-HTTP deployments.
+export function copyText(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text);
+  }
+
+  return new Promise((resolve, reject) => {
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      const ok = document.execCommand("copy");
+      document.body.removeChild(ta);
+
+      if (ok) {
+        resolve();
+      } else {
+        reject(new Error("copy command rejected"));
+      }
+    } catch (e) {
+      reject(e);
+    }
+  });
+}

--- a/packages/shim/src/util/clipboard.test.js
+++ b/packages/shim/src/util/clipboard.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { copyText } from "./clipboard.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("copyText", () => {
+  it("uses navigator.clipboard when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    await copyText("hello");
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to a textarea + execCommand when clipboard is unavailable", async () => {
+    vi.stubGlobal("navigator", {});
+    const ta = { style: {}, value: "", select: vi.fn() };
+    const removeChild = vi.fn();
+    const execCommand = vi.fn(() => true);
+    vi.stubGlobal("document", {
+      createElement: vi.fn(() => ta),
+      body: { appendChild: vi.fn(), removeChild },
+      execCommand,
+    });
+
+    await expect(copyText("hello")).resolves.toBeUndefined();
+
+    expect(ta.value).toBe("hello");
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(removeChild).toHaveBeenCalledWith(ta);
+  });
+
+  it("rejects when the fallback copy command fails", async () => {
+    vi.stubGlobal("navigator", {});
+    vi.stubGlobal("document", {
+      createElement: () => ({ style: {}, value: "", select: () => {} }),
+      body: { appendChild: () => {}, removeChild: () => {} },
+      execCommand: () => false,
+    });
+
+    await expect(copyText("x")).rejects.toThrow("copy command rejected");
+  });
+});

--- a/packages/shim/src/util/proxy.js
+++ b/packages/shim/src/util/proxy.js
@@ -12,7 +12,10 @@ export async function proxyFetch({ url, method, headers, body, contentType }) {
     encodedBody = arrayBufferToBase64(body);
     binary = true;
   } else if (body instanceof Uint8Array) {
-    encodedBody = arrayBufferToBase64(body.buffer);
+    // A Uint8Array can be a view into a larger buffer (nonzero byteOffset, or shorter byteLength), so encode only the view's region.
+    encodedBody = arrayBufferToBase64(
+      body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+    );
     binary = true;
   } else if (body != null) {
     encodedBody = body;

--- a/packages/shim/src/util/proxy.test.js
+++ b/packages/shim/src/util/proxy.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { proxyFetch } from "./proxy.js";
+
+function fakeResponse() {
+  return {
+    ok: true,
+    json: async () => ({ status: 200, headers: {}, body: "" }),
+  };
+}
+
+// proxyFetch reads window.__originalFetch to reach the server proxy.
+function captureWith(handler) {
+  globalThis.window = {
+    __originalFetch: async (url, opts) => {
+      handler(JSON.parse(opts.body));
+      return fakeResponse();
+    },
+  };
+}
+
+describe("proxyFetch binary body encoding", () => {
+  afterEach(() => {
+    delete globalThis.window;
+  });
+
+  it("encodes only a Uint8Array view's own region, not its backing buffer", async () => {
+    let payload = null;
+    captureWith((p) => (payload = p));
+
+    const pool = new Uint8Array(32);
+
+    for (let i = 0; i < pool.length; i++) {
+      pool[i] = i;
+    }
+
+    const view = pool.subarray(8, 20); // 12 bytes at offset 8
+
+    await proxyFetch({
+      url: "https://example.com/x",
+      method: "PUT",
+      body: view,
+    });
+
+    expect(payload.binary).toBe(true);
+    const decoded = Buffer.from(payload.body, "base64");
+    expect(decoded.length).toBe(view.byteLength);
+    expect([...decoded]).toEqual([...view]);
+  });
+
+  it("encodes a full ArrayBuffer", async () => {
+    let payload = null;
+    captureWith((p) => (payload = p));
+
+    const body = new Uint8Array([1, 2, 3, 4, 5]).buffer;
+
+    await proxyFetch({ url: "https://example.com/x", method: "PUT", body });
+
+    expect(payload.binary).toBe(true);
+    const decoded = Buffer.from(payload.body, "base64");
+    expect([...decoded]).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("passes a string body through untouched and unflagged", async () => {
+    let payload = null;
+    captureWith((p) => (payload = p));
+
+    await proxyFetch({
+      url: "https://example.com/x",
+      method: "PUT",
+      body: "héllo \u{1F600}",
+    });
+
+    expect(payload.binary).toBe(false);
+    expect(payload.body).toBe("héllo \u{1F600}");
+  });
+});


### PR DESCRIPTION
# 0.8.8 (Karm)

- boot prefetch skips plugin asset directories and reads batches in parallel.
- write durability: failed writes now retry in the background with backoff.
- NFS-mounted vaults: startup chown no longer aborts on root_squash or read-only mounts.
- spellcheck languages setting disabled with a link to the browser's own language settings, since a web page can't set the browser's spellchecker

bugfixes:
- webdav uploads through the proxy no longer corrupt; content-length is recomputed from the request body (fixes remotely-save)

security:
- resolveVaultPath now resolves symlinks and confines access within the vault's real path, so an in-vault symlink can't read/write outside it

closes #39, closes #43, closes #44.