### PR TITLE
feat(server): listen on a unix domain socket via SOCKET_PATH

### DIFF
--- a/apps/docs/src/content/docs/server/environment.md
+++ b/apps/docs/src/content/docs/server/environment.md
@@ -9,7 +9,8 @@ Configure the server through environment variables, set in the `environment:` bl
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `PORT` | `8080` | Port the server listens on. |
+| `PORT` | `8080` | Port the server listens on. Ignored when `SOCKET_PATH` is set. |
+| `SOCKET_PATH` | _(unset)_ | Listen on a unix domain socket at this path instead of a TCP port. Useful behind a reverse proxy: bind-mount the socket directory and no port needs to be published. The socket is created mode `0666`; a stale socket file at the path is removed on startup. |
 | `VAULT_ROOT` | `/vaults` | Directory holding your vaults, one sub-folder per vault. |
 | `DATA_ROOT` | `/app/data` | Directory for Ignis state: server plugin config, sync state, and tokens. |
 

--- a/apps/ignis-server/server/config.js
+++ b/apps/ignis-server/server/config.js
@@ -79,6 +79,7 @@ let vaults = discoverVaults();
 
 module.exports = {
   port: process.env.PORT || 8080,
+  socketPath: process.env.SOCKET_PATH || null,
   vaultRoot,
   dataRoot,
   get vaults() {

--- a/apps/ignis-server/server/index.js
+++ b/apps/ignis-server/server/index.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const compression = require("compression");
 const config = require("./config");
+const { listen: listenOn, cleanup: cleanupSocket } = require("./listen");
 const settings = require("./settings");
 const { getVersion } = require("./version");
 const { versionedSrc, cacheControlFor } = require("./cache-headers");
@@ -194,13 +195,8 @@ app.use(express.static(path.join(REPO_ROOT, "packages", "shim", "dist")));
 
 app.use(express.static(config.obsidianAssetsPath));
 
-if (config.socketPath && fs.existsSync(config.socketPath)) {
-  fs.unlinkSync(config.socketPath); // stale socket from unclean shutdown blocks bind
-}
-
-const server = app.listen(config.socketPath ?? config.port, async () => {
+const server = listenOn(app, config, async () => {
   if (config.socketPath) {
-    fs.chmodSync(config.socketPath, 0o666); // reverse proxy runs as another user
     console.log(`[ignis] Server running on unix socket ${config.socketPath}`);
   } else {
     console.log(`[ignis] Server running on http://localhost:${config.port}`);
@@ -239,9 +235,7 @@ async function gracefulShutdown(signal) {
   await shutdownPlugins();
 
   server.close(() => {
-    if (config.socketPath && fs.existsSync(config.socketPath)) {
-      fs.unlinkSync(config.socketPath);
-    }
+    cleanupSocket(config);
     console.log("[ignis] Server closed");
     process.exit(0);
   });

--- a/apps/ignis-server/server/index.js
+++ b/apps/ignis-server/server/index.js
@@ -194,8 +194,17 @@ app.use(express.static(path.join(REPO_ROOT, "packages", "shim", "dist")));
 
 app.use(express.static(config.obsidianAssetsPath));
 
-const server = app.listen(config.port, async () => {
-  console.log(`[ignis] Server running on http://localhost:${config.port}`);
+if (config.socketPath && fs.existsSync(config.socketPath)) {
+  fs.unlinkSync(config.socketPath); // stale socket from unclean shutdown blocks bind
+}
+
+const server = app.listen(config.socketPath ?? config.port, async () => {
+  if (config.socketPath) {
+    fs.chmodSync(config.socketPath, 0o666); // reverse proxy runs as another user
+    console.log(`[ignis] Server running on unix socket ${config.socketPath}`);
+  } else {
+    console.log(`[ignis] Server running on http://localhost:${config.port}`);
+  }
   console.log(`[ignis] Vault root: ${config.vaultRoot}`);
   console.log(`[ignis] Vaults: ${Object.keys(config.vaults).join(", ")}`);
 
@@ -230,6 +239,9 @@ async function gracefulShutdown(signal) {
   await shutdownPlugins();
 
   server.close(() => {
+    if (config.socketPath && fs.existsSync(config.socketPath)) {
+      fs.unlinkSync(config.socketPath);
+    }
     console.log("[ignis] Server closed");
     process.exit(0);
   });

--- a/apps/ignis-server/server/listen.js
+++ b/apps/ignis-server/server/listen.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+
+// Binds the app to config.socketPath (unix domain socket) or config.port (TCP).
+function listen(app, config, onReady) {
+  if (config.socketPath && fs.existsSync(config.socketPath)) {
+    fs.unlinkSync(config.socketPath); // stale socket from an unclean shutdown blocks the bind
+  }
+  return app.listen(config.socketPath ?? config.port, () => {
+    if (config.socketPath) {
+      fs.chmodSync(config.socketPath, 0o666); // a reverse proxy runs as another user
+    }
+    if (onReady) onReady();
+  });
+}
+
+// Removes the socket file after the server closes.
+function cleanup(config) {
+  if (config.socketPath && fs.existsSync(config.socketPath)) {
+    fs.unlinkSync(config.socketPath);
+  }
+}
+
+module.exports = { listen, cleanup };

--- a/apps/ignis-server/server/listen.test.mjs
+++ b/apps/ignis-server/server/listen.test.mjs
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+
+const require = createRequire(import.meta.url);
+const { listen, cleanup } = require("./listen.js");
+
+// Express-shaped stand-in: app.listen(target, cb) delegating to a plain http server.
+function makeApp() {
+  return {
+    listen: (target, cb) =>
+      http
+        .createServer((req, res) => {
+          res.end("ok");
+        })
+        .listen(target, cb),
+  };
+}
+
+function requestOverSocket(socketPath) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ socketPath, path: "/" }, (res) => {
+      let body = "";
+      res.on("data", (c) => (body += c));
+      res.on("end", () => resolve({ status: res.statusCode, body }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+// Unix domain sockets are unavailable on Windows; skip those cases where binding fails.
+let canBindSocket = false;
+try {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "ignis-socket-probe-"));
+  const probePath = path.join(probeDir, "probe.sock");
+  const srv = http.createServer();
+  await new Promise((resolve, reject) => {
+    srv.once("error", reject);
+    srv.listen(probePath, resolve);
+  });
+  canBindSocket = true;
+  await new Promise((resolve) => srv.close(resolve));
+  fs.rmSync(probeDir, { recursive: true, force: true });
+} catch {
+  canBindSocket = false;
+}
+
+function tmpSocketPath() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ignis-listen-test-"));
+  return path.join(dir, "server.sock");
+}
+
+describe("listen", () => {
+  it("listens on a TCP port when socketPath is unset", async () => {
+    const server = listen(makeApp(), { socketPath: null, port: 0 });
+    await new Promise((resolve) => server.once("listening", resolve));
+    expect(server.address().port).toBeGreaterThan(0);
+    await closeServer(server);
+  });
+
+  it.skipIf(!canBindSocket)("listens on a unix socket and serves requests", async () => {
+    const socketPath = tmpSocketPath();
+    const server = listen(makeApp(), { socketPath, port: 8080 });
+    await new Promise((resolve) => server.once("listening", resolve));
+
+    const res = await requestOverSocket(socketPath);
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("ok");
+
+    await closeServer(server);
+  });
+
+  it.skipIf(!canBindSocket)("makes the socket connectable by other users (0666)", async () => {
+    const socketPath = tmpSocketPath();
+    const server = listen(makeApp(), { socketPath, port: 8080 });
+    await new Promise((resolve) => server.once("listening", resolve));
+
+    expect(fs.statSync(socketPath).mode & 0o777).toBe(0o666);
+
+    await closeServer(server);
+  });
+
+  it.skipIf(!canBindSocket)("removes a stale socket file before binding", async () => {
+    const socketPath = tmpSocketPath();
+    fs.writeFileSync(socketPath, ""); // leftover from an unclean shutdown
+
+    const server = listen(makeApp(), { socketPath, port: 8080 });
+    await new Promise((resolve) => server.once("listening", resolve));
+
+    const res = await requestOverSocket(socketPath);
+    expect(res.status).toBe(200);
+
+    await closeServer(server);
+  });
+
+  it.skipIf(!canBindSocket)("cleanup removes the socket file", async () => {
+    const socketPath = tmpSocketPath();
+    const server = listen(makeApp(), { socketPath, port: 8080 });
+    await new Promise((resolve) => server.once("listening", resolve));
+    await closeServer(server);
+
+    cleanup({ socketPath });
+    expect(fs.existsSync(socketPath)).toBe(false);
+  });
+
+  it("cleanup is a no-op without socketPath", () => {
+    expect(() => cleanup({ socketPath: null })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Why

When Ignis runs behind a reverse proxy, the published TCP port is only ever used by the proxy. A unix domain socket does the same job without claiming a port: the proxy dials the socket file directly, and nothing needs to be published with `-p`.

## What

- New environment variable `SOCKET_PATH`, documented in `environment.md`. When set, the server listens on that unix socket and `PORT` is ignored.
- A stale socket file at the path is removed on startup, since an unclean shutdown would otherwise block the bind.
- The socket is chmod `0666` after bind so a proxy running as a different user can connect.
- Graceful shutdown removes the socket file.
- WebSockets are unaffected: `setupWebSocket` attaches to the same `http.Server`, and upgrade requests work the same over unix sockets.
- With `SOCKET_PATH` unset, behavior is unchanged.

## Testing

Built the image from this branch and ran it with the socket directory bind mounted:

```
podman run -d \
  -v ./vaults:/vaults -v ./data:/app/data -v /run/proxy:/run/proxy \
  -e SOCKET_PATH=/run/proxy/ignis.sock \
  <image>
```

Caddy configured with `reverse_proxy unix//run/proxy/ignis.sock` serves the full UI. Verified HTTP 200 on `/` and a `101 Switching Protocols` websocket upgrade through the socket.

The listen logic is extracted into `listen.js` with a colocated `listen.test.mjs` (unix socket cases probe for support and skip on Windows, matching the symlink probe in `config.test.mjs`). `npm test` (283 passing) and `npm run lint` are clean.