### PR TITLE
fix: Vault selector is broken in mobile emulated mode

### DIFF
--- a/packages/shim/src/electron/ipc-renderer.js
+++ b/packages/shim/src/electron/ipc-renderer.js
@@ -113,6 +113,12 @@ export const ipcRenderer = {
   send(channel, ...args) {
     console.log("[shim:ipcRenderer] send:", channel, args);
 
+    if (syncHandlers[channel]) {
+      const result = syncHandlers[channel](...args);
+      queueMicrotask(() => ipcRenderer._emit(channel, result));
+      return;
+    }
+
     if (channel === "context-menu") {
       queueMicrotask(() =>
         ipcRenderer._emit("context-menu", {


### PR DESCRIPTION
Fixes #13.

## Summary

Vault selector is broken in mobile emulated mode

## Validation

- Mechanical gate: +6/-0, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->